### PR TITLE
Allow github-actions[bot] to trigger Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude:
     if: |
-      github.actor == github.repository_owner &&
+      (github.actor == github.repository_owner || github.actor == 'github-actions[bot]') &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
The sprint planning workflow posts @claude comments as github-actions[bot]. Previously, only the repository owner could trigger Claude, so bot-posted comments were silently ignored.