### PR TITLE
Fix: GitHub ActionsからClaudeを直接呼び出す

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude:
     if: |
-      (github.actor == github.repository_owner || github.actor == 'github-actions[bot]') &&
+      github.actor == github.repository_owner &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||

--- a/.github/workflows/weekly-sprint-planning.yml
+++ b/.github/workflows/weekly-sprint-planning.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   create_sprint_issue:
     runs-on: ubuntu-latest
+    outputs:
+      issue_number: ${{ steps.create_issue.outputs.issue_number }}
     permissions:
       contents: read
       issues: write
@@ -72,6 +74,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Sprint Planning Issue
+        id: create_issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TZ: Asia/Tokyo
@@ -102,23 +105,19 @@ jobs:
             echo ""
             echo "### 📝 Planning Tasks"
             echo ""
-            echo "- [ ] **Review** previous week's feedback and metrics"
-            echo "- [ ] **Select** 3-5 features/fixes for this sprint"
+            echo "- [ ] **Review** Claude's proposals below and select features for this sprint"
             echo "- [ ] **Assign** tasks to developers"
-            echo "- [ ] **Comment** with approved sprint scope: \`@claude plan\`"
+            echo "- [ ] **Comment** with approved sprint scope: \`@claude implement\`"
             echo ""
             echo "### 💬 Next Steps"
             echo ""
             echo "Once you've finalized the scope, mention \`@claude\` in a comment:"
             echo '```'
-            echo "@claude plan"
-            echo "Selected features for this sprint:"
+            echo "@claude implement"
+            echo "Please implement the following features:"
             echo "1. Feature A"
             echo "2. Feature B"
-            echo "3. Bug fix C"
             echo '```'
-            echo ""
-            echo "Claude will create detailed implementation plans for each item."
           } > /tmp/issue_body.md
 
           ISSUE_URL=$(gh issue create \
@@ -126,40 +125,60 @@ jobs:
             --body-file /tmp/issue_body.md \
             --label "sprint-planning,sprint")
           ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
 
-          {
-            echo "@claude"
-            echo ""
-            echo "You are a product strategist for **Makasete AI** — a spreadsheet-driven AI chatbot"
-            echo "for Japanese e-commerce and service sites, featuring real-time voice interaction"
-            echo "and low-latency streaming TTS."
-            echo ""
-            echo "## Phase 1: Competitive & Market Research"
-            echo ""
-            echo "Search the web and gather insights on the following:"
-            echo ""
-            echo "1. **Competitor products** — Search for AI chatbot / voice assistant solutions"
-            echo "   targeting Japanese e-commerce (keywords: 'ECサイト AIチャットボット', 'AI voice"
-            echo "   assistant ecommerce Japan', 'shopify chatbot AI Japan 2025'). For each"
-            echo "   competitor found, note: key features, pricing model, and gaps."
-            echo ""
-            echo "2. **Market trends** — Search for recent trends in conversational AI and voice"
-            echo "   commerce (keywords: 'voice commerce trends 2025', 'AI chatbot ecommerce"
-            echo "   conversion rate', 'LLM customer support SaaS 2025'). Identify 2-3 trends"
-            echo "   most relevant to Makasete AI."
-            echo ""
-            echo "## Phase 2: Feature Proposals"
-            echo ""
-            echo "Based on your research AND the open issues listed in this sprint planning issue,"
-            echo "propose 3-5 feature candidates for this week's sprint."
-            echo ""
-            echo "For each proposal, provide:"
-            echo "- **Feature name** (one line)"
-            echo "- **Why now** — competitive gap, market trend, or user pain point driving it"
-            echo "- **Scope estimate** — S / M / L (S = 1 day, M = 2-3 days, L = 4-5 days)"
-            echo "- **Success metric** — how we know it worked"
-            echo ""
-            echo "Rank proposals by impact-to-effort ratio. Reply in Japanese."
-          } > /tmp/claude_comment.md
+  claude_proposals:
+    needs: create_sprint_issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/claude_comment.md
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are a product strategist for **Makasete AI** — a spreadsheet-driven AI chatbot
+            for Japanese e-commerce and service sites, featuring real-time voice interaction
+            and low-latency streaming TTS.
+
+            ## Phase 1: Competitive & Market Research
+
+            Search the web and gather insights on the following:
+
+            1. **Competitor products** — Search for AI chatbot / voice assistant solutions
+               targeting Japanese e-commerce (keywords: 'ECサイト AIチャットボット', 'AI voice
+               assistant ecommerce Japan', 'shopify chatbot AI Japan 2025'). For each
+               competitor found, note: key features, pricing model, and gaps.
+
+            2. **Market trends** — Search for recent trends in conversational AI and voice
+               commerce (keywords: 'voice commerce trends 2025', 'AI chatbot ecommerce
+               conversion rate', 'LLM customer support SaaS 2025'). Identify 2-3 trends
+               most relevant to Makasete AI.
+
+            ## Phase 2: Feature Proposals
+
+            Based on your research AND the open issues in this repository, propose 3-5 feature
+            candidates for this week's sprint.
+
+            For each proposal, provide:
+            - **Feature name** (one line)
+            - **Why now** — competitive gap, market trend, or user pain point driving it
+            - **Scope estimate** — S / M / L (S = 1 day, M = 2-3 days, L = 4-5 days)
+            - **Success metric** — how we know it worked
+
+            Rank proposals by impact-to-effort ratio.
+
+            ## Post Results
+
+            Post your full analysis as a comment on GitHub issue #${{ needs.create_sprint_issue.outputs.issue_number }}
+            by running:
+              gh issue comment ${{ needs.create_sprint_issue.outputs.issue_number }} --body "<your analysis in Japanese>"


### PR DESCRIPTION
## 問題

`GITHUB_TOKEN` で投稿したコメントは他のワークフローをトリガーできない（GitHub のセキュリティ制限）。そのため `@claude` コメントを投稿しても `claude.yml` が起動せず、Claude が無反応だった。

## 解決策

`weekly-sprint-planning.yml` を2ジョブ構成に変更：

1. `create_sprint_issue` — Issue 作成（従来通り）
2. `claude_proposals` — `claude-code-action` を直接呼び出し、競合調査・機能提案を Issue にコメント投稿

コメント経由の連鎖をやめ、Claude を直接起動することで確実に動作する。

## Test plan

- [ ] `workflow_dispatch` で `weekly-sprint-planning.yml` を手動実行
- [ ] Issue が作成されること
- [ ] Claude が競合調査・機能提案コメントを Issue に投稿すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)