### PR TITLE
Fix: Claudeに gh issue comment 等のツール使用を許可

### DIFF
--- a/.github/workflows/weekly-release-prep.yml
+++ b/.github/workflows/weekly-release-prep.yml
@@ -15,7 +15,7 @@ jobs:
       issues: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: develop

--- a/.github/workflows/weekly-sprint-planning.yml
+++ b/.github/workflows/weekly-sprint-planning.yml
@@ -145,6 +145,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowed-tools "Bash(gh issue comment:*),Bash(gh issue list:*),Bash(gh issue view:*),WebSearch,WebFetch"'
           prompt: |
             You are a product strategist for **Makasete AI** — a spreadsheet-driven AI chatbot
             for Japanese e-commerce and service sites, featuring real-time voice interaction

--- a/.github/workflows/weekly-sprint-planning.yml
+++ b/.github/workflows/weekly-sprint-planning.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -136,7 +136,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## 問題

PR #204 マージ後の動作確認で、Claude が分析を実行したものの **Issue にコメントを投稿していなかった**。

ログを確認したところ:
\`\`\`
"permission_denials_count": 7
\`\`\`

\`claude-code-action\` のデフォルト許可ツールに \`gh issue comment\` や \`WebSearch\` が含まれていないため、Claude が実行を 7 回拒否されていた。

## 修正

\`claude_args\` に \`--allowed-tools\` を追加し、必要なツールを明示的に許可:
- \`Bash(gh issue comment:*)\` — Issue へのコメント投稿
- \`Bash(gh issue list:*)\` — Open Issue の取得
- \`Bash(gh issue view:*)\` — Issue 詳細の取得
- \`WebSearch\`, \`WebFetch\` — 競合・市場調査

## 補足

ログに出ていた以下の警告は内部的なもので実害なし:
> Internal error: directory mismatch for directory "/home/runner/work/_actions/anthropics/claude-code-action/v1/tsconfig.json"
> "You don't need to do anything, but this indicates a bug."

## Test plan

- [ ] \`workflow_dispatch\` で \`weekly-sprint-planning.yml\` を手動実行
- [ ] Claude が作成した Issue に分析コメントを投稿すること
- [ ] \`permission_denials_count\` が 0 になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)