### PR TITLE
refactor: server/index.ts からSocket.ioハンドラとTTS処理を分離

### DIFF
--- a/server/handlers/socketConnectionHandler.ts
+++ b/server/handlers/socketConnectionHandler.ts
@@ -1,0 +1,136 @@
+import { Socket } from "socket.io";
+import { getAllSheetData } from "../services/sheets";
+import { generateResponseStream } from "../services/gemini";
+import { getTTSService } from "../services/tts/factory";
+import { TTSService } from "../services/tts/types";
+import { StreamBuffer } from "../utils/streamBuffer";
+import {
+  stripTags,
+  cleanupForTTS,
+  hasTags,
+  removeMarkdownLinks,
+} from "../utils/text";
+
+export function registerConnectionHandler(
+  socket: Socket,
+  socketConnections: Map<string, number>,
+  getClientIp: (socket: Socket) => string,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chatHistory: any[] = [];
+
+  socket.on(
+    "user-input",
+    async (data: { text: string; isVoiceInput: boolean }) => {
+      const { text, isVoiceInput } = data;
+
+      if (!text || typeof text !== "string" || text.length > 1000) {
+        socket.emit("error", { message: "Input is invalid" });
+        return;
+      }
+
+      chatHistory.push({ role: "user", parts: [{ text }] });
+
+      if (chatHistory.length > 20) {
+        chatHistory.splice(0, 2);
+      }
+
+      const streamBuffer = new StreamBuffer();
+
+      try {
+        const allData = getAllSheetData();
+        const stream = await generateResponseStream(text, allData, chatHistory);
+        const ttsService = getTTSService();
+
+        let fullResponseText = "";
+
+        for await (const chunk of stream) {
+          const chunkText = chunk.text();
+          fullResponseText += chunkText;
+
+          const sentences = streamBuffer.add(chunkText);
+
+          for (const sentence of sentences) {
+            await processSentence(socket, sentence, isVoiceInput, ttsService);
+          }
+        }
+
+        const remaining = streamBuffer.flush();
+        if (remaining) {
+          await processSentence(socket, remaining, isVoiceInput, ttsService);
+        }
+
+        chatHistory.push({
+          role: "model",
+          parts: [{ text: fullResponseText }],
+        });
+
+        socket.emit("response-complete");
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("Error processing input:", message);
+        socket.emit("error", { message: "Internal server error occurred." });
+      }
+    },
+  );
+
+  socket.on("disconnect", () => {
+    const clientIp = getClientIp(socket);
+    const count = socketConnections.get(clientIp);
+    if (count && count > 1) {
+      socketConnections.set(clientIp, count - 1);
+    } else {
+      socketConnections.delete(clientIp);
+    }
+  });
+}
+
+async function processSentence(
+  socket: Socket,
+  sentence: string,
+  isVoiceInput: boolean,
+  ttsService: TTSService,
+) {
+  const uiText = stripTags(sentence);
+
+  if (isVoiceInput) {
+    socket.emit("audio-chunk", { type: "text", content: uiText });
+
+    try {
+      let ttsInput: string;
+      if (hasTags(sentence)) {
+        const innerText = sentence.replace(/<\/?speak>/g, "").trim();
+        ttsInput = `<speak>${removeMarkdownLinks(innerText)}</speak>`;
+      } else {
+        ttsInput = cleanupForTTS(sentence);
+      }
+
+      if (!ttsInput.trim() || !stripTags(ttsInput).trim()) return;
+
+      const audioStream: NodeJS.ReadableStream =
+        await ttsService.generateSpeechStream(ttsInput);
+
+      const chunks: Buffer[] = [];
+      audioStream.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      await new Promise((resolve, reject) => {
+        audioStream.on("end", () => {
+          const fullBuffer = Buffer.concat(chunks);
+          socket.emit("audio-chunk", { type: "audio", content: fullBuffer });
+          setTimeout(resolve, 50);
+        });
+        audioStream.on("error", (err) => {
+          console.error("[TTS] Stream error:", err);
+          reject(err);
+        });
+      });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error("TTS Error:", message);
+    }
+  } else {
+    socket.emit("text-chunk", { content: uiText });
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,16 +10,7 @@ import {
   getAllSheetData,
   dataReadyPromise,
 } from "./services/sheets";
-import { generateResponseStream } from "./services/gemini";
-import { getTTSService } from "./services/tts/factory";
-import { TTSService } from "./services/tts/types";
-import { StreamBuffer } from "./utils/streamBuffer";
-import {
-  stripTags,
-  cleanupForTTS,
-  hasTags,
-  removeMarkdownLinks,
-} from "./utils/text";
+import { registerConnectionHandler } from "./handlers/socketConnectionHandler";
 
 const app = express();
 
@@ -132,138 +123,9 @@ fetchAllSheets().then(() => {
 });
 
 // WebSocket logic
-io.on("connection", (socket) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const chatHistory: any[] = [];
-
-  socket.on(
-    "user-input",
-    async (data: { text: string; isVoiceInput: boolean }) => {
-      const { text, isVoiceInput } = data;
-
-      if (!text || typeof text !== "string" || text.length > 1000) {
-        socket.emit("error", { message: "Input is invalid" });
-        return;
-      }
-
-      chatHistory.push({ role: "user", parts: [{ text }] });
-
-      if (chatHistory.length > 20) {
-        chatHistory.splice(0, 2);
-      }
-
-      const streamBuffer = new StreamBuffer();
-
-      try {
-        // 1. Fetch sheet data in the orchestration layer and inject into Gemini service
-        const allData = getAllSheetData();
-
-        // 2. Get Gemini Stream, passing sheet data via dependency injection
-        const stream = await generateResponseStream(text, allData, chatHistory);
-        const ttsService = getTTSService();
-
-        let fullResponseText = "";
-
-        for await (const chunk of stream) {
-          const chunkText = chunk.text();
-          fullResponseText += chunkText;
-
-          // Buffer and split by sentences
-          const sentences = streamBuffer.add(chunkText);
-
-          for (const sentence of sentences) {
-            await processSentence(socket, sentence, isVoiceInput, ttsService);
-          }
-        }
-
-        // Flush remaining buffer
-        const remaining = streamBuffer.flush();
-        if (remaining) {
-          await processSentence(socket, remaining, isVoiceInput, ttsService);
-        }
-
-        // Add model response to history
-        chatHistory.push({
-          role: "model",
-          parts: [{ text: fullResponseText }],
-        });
-
-        // Signal end of turn
-        socket.emit("response-complete");
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error("Error processing input:", message);
-        socket.emit("error", { message: "Internal server error occurred." });
-      }
-    },
-  );
-
-  socket.on("disconnect", () => {
-    const clientIp = getClientIp(socket);
-    const count = socketConnections.get(clientIp);
-    if (count && count > 1) {
-      socketConnections.set(clientIp, count - 1);
-    } else {
-      socketConnections.delete(clientIp);
-    }
-  });
-});
-
-async function processSentence(
-  socket: Socket,
-  sentence: string,
-  isVoiceInput: boolean,
-  ttsService: TTSService,
-) {
-  // 1. Prepare text for UI by removing SSML tags
-  const uiText = stripTags(sentence);
-
-  if (isVoiceInput) {
-    // Send clean text to UI
-    socket.emit("audio-chunk", { type: "text", content: uiText });
-
-    try {
-      // 2. Prepare text for TTS
-      let ttsInput: string;
-      if (hasTags(sentence)) {
-        // Ensure it's a valid SSML document and clean it up
-        const innerText = sentence.replace(/<\/?speak>/g, "").trim();
-        ttsInput = `<speak>${removeMarkdownLinks(innerText)}</speak>`;
-      } else {
-        // Plain text handling
-        ttsInput = cleanupForTTS(sentence);
-      }
-
-      // Skip if no actual text to read
-      if (!ttsInput.trim() || !stripTags(ttsInput).trim()) return;
-
-      const audioStream: NodeJS.ReadableStream =
-        await ttsService.generateSpeechStream(ttsInput);
-
-      const chunks: Buffer[] = [];
-      audioStream.on("data", (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-
-      await new Promise((resolve, reject) => {
-        audioStream.on("end", () => {
-          const fullBuffer = Buffer.concat(chunks);
-          socket.emit("audio-chunk", { type: "audio", content: fullBuffer });
-          setTimeout(resolve, 50); // Minimal gap
-        });
-        audioStream.on("error", (err) => {
-          console.error("[TTS] Stream error:", err);
-          reject(err);
-        });
-      });
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : String(e);
-      console.error("TTS Error:", message);
-    }
-  } else {
-    socket.emit("text-chunk", { content: uiText });
-  }
-}
+io.on("connection", (socket) =>
+  registerConnectionHandler(socket, socketConnections, getClientIp),
+);
 
 // Start Server
 const PORT = config.port;


### PR DESCRIPTION
## Summary

- `server/index.ts` に混在していたSocket.ioイベントハンドラ（`user-input` / `disconnect`）と `processSentence` 関数を `server/handlers/socketConnectionHandler.ts` へ移動
- `server/index.ts` はサーバー起動・ミドルウェア・ルート登録のみを担う薄いエントリーポイントに（273行 → 約130行）
- `socketConnections` Map と `getClientIp` は `io.use()` ミドルウェアとの共有が必要なため `index.ts` に残し、引数で注入する設計

## 変更ファイル

- **新規作成**: `server/handlers/socketConnectionHandler.ts`
- **更新**: `server/index.ts`（不要なimport削除、ハンドラ登録を1行に集約）

## Test plan

- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test` — 32テスト全通過

https://claude.ai/code/session_01FWKw2GbwnF2ZGMPBj2kPDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWKw2GbwnF2ZGMPBj2kPDp)_