### PR TITLE
refactor: Socket.io ハンドラとビジネスロジックを ChatService に分離 (#80)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -10,16 +10,7 @@ import {
   getAllSheetData,
   dataReadyPromise,
 } from "./services/sheets";
-import { generateResponseStream } from "./services/gemini";
-import { getTTSService } from "./services/tts/factory";
-import { TTSService } from "./services/tts/types";
-import { StreamBuffer } from "./utils/streamBuffer";
-import {
-  stripTags,
-  cleanupForTTS,
-  hasTags,
-  removeMarkdownLinks,
-} from "./utils/text";
+import { ChatService } from "./services/chat";
 
 const app = express();
 
@@ -133,68 +124,12 @@ fetchAllSheets().then(() => {
 
 // WebSocket logic
 io.on("connection", (socket) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const chatHistory: any[] = [];
+  const chatService = new ChatService();
 
   socket.on(
     "user-input",
-    async (data: { text: string; isVoiceInput: boolean }) => {
-      const { text, isVoiceInput } = data;
-
-      if (!text || typeof text !== "string" || text.length > 1000) {
-        socket.emit("error", { message: "Input is invalid" });
-        return;
-      }
-
-      chatHistory.push({ role: "user", parts: [{ text }] });
-
-      if (chatHistory.length > 20) {
-        chatHistory.splice(0, 2);
-      }
-
-      const streamBuffer = new StreamBuffer();
-
-      try {
-        // 1. Fetch sheet data in the orchestration layer and inject into Gemini service
-        const allData = getAllSheetData();
-
-        // 2. Get Gemini Stream, passing sheet data via dependency injection
-        const stream = await generateResponseStream(text, allData, chatHistory);
-        const ttsService = getTTSService();
-
-        let fullResponseText = "";
-
-        for await (const chunk of stream) {
-          const chunkText = chunk.text();
-          fullResponseText += chunkText;
-
-          // Buffer and split by sentences
-          const sentences = streamBuffer.add(chunkText);
-
-          for (const sentence of sentences) {
-            await processSentence(socket, sentence, isVoiceInput, ttsService);
-          }
-        }
-
-        // Flush remaining buffer
-        const remaining = streamBuffer.flush();
-        if (remaining) {
-          await processSentence(socket, remaining, isVoiceInput, ttsService);
-        }
-
-        // Add model response to history
-        chatHistory.push({
-          role: "model",
-          parts: [{ text: fullResponseText }],
-        });
-
-        // Signal end of turn
-        socket.emit("response-complete");
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error("Error processing input:", message);
-        socket.emit("error", { message: "Internal server error occurred." });
-      }
+    (data: { text: string; isVoiceInput: boolean }) => {
+      chatService.handleUserInput(socket, data);
     },
   );
 
@@ -208,62 +143,6 @@ io.on("connection", (socket) => {
     }
   });
 });
-
-async function processSentence(
-  socket: Socket,
-  sentence: string,
-  isVoiceInput: boolean,
-  ttsService: TTSService,
-) {
-  // 1. Prepare text for UI by removing SSML tags
-  const uiText = stripTags(sentence);
-
-  if (isVoiceInput) {
-    // Send clean text to UI
-    socket.emit("audio-chunk", { type: "text", content: uiText });
-
-    try {
-      // 2. Prepare text for TTS
-      let ttsInput: string;
-      if (hasTags(sentence)) {
-        // Ensure it's a valid SSML document and clean it up
-        const innerText = sentence.replace(/<\/?speak>/g, "").trim();
-        ttsInput = `<speak>${removeMarkdownLinks(innerText)}</speak>`;
-      } else {
-        // Plain text handling
-        ttsInput = cleanupForTTS(sentence);
-      }
-
-      // Skip if no actual text to read
-      if (!ttsInput.trim() || !stripTags(ttsInput).trim()) return;
-
-      const audioStream: NodeJS.ReadableStream =
-        await ttsService.generateSpeechStream(ttsInput);
-
-      const chunks: Buffer[] = [];
-      audioStream.on("data", (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-
-      await new Promise((resolve, reject) => {
-        audioStream.on("end", () => {
-          const fullBuffer = Buffer.concat(chunks);
-          socket.emit("audio-chunk", { type: "audio", content: fullBuffer });
-          setTimeout(resolve, 50); // Minimal gap
-        });
-        audioStream.on("error", (err) => {
-          console.error("[TTS] Stream error:", err);
-          reject(err);
-        });
-      });
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : String(e);
-      console.error("TTS Error:", message);
-    }
-  } else {
-    socket.emit("text-chunk", { content: uiText });
-  }
-}
 
 // Start Server
 const PORT = config.port;

--- a/server/services/chat.ts
+++ b/server/services/chat.ts
@@ -1,0 +1,120 @@
+import { Socket } from "socket.io";
+import { getAllSheetData } from "./sheets";
+import { generateResponseStream } from "./gemini";
+import { getTTSService } from "./tts/factory";
+import { TTSService } from "./tts/types";
+import { StreamBuffer } from "../utils/streamBuffer";
+import {
+  stripTags,
+  cleanupForTTS,
+  hasTags,
+  removeMarkdownLinks,
+} from "../utils/text";
+
+export class ChatService {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private chatHistory: any[] = [];
+
+  async handleUserInput(
+    socket: Socket,
+    data: { text: string; isVoiceInput: boolean },
+  ): Promise<void> {
+    const { text, isVoiceInput } = data;
+
+    if (!text || typeof text !== "string" || text.length > 1000) {
+      socket.emit("error", { message: "Input is invalid" });
+      return;
+    }
+
+    this.chatHistory.push({ role: "user", parts: [{ text }] });
+    if (this.chatHistory.length > 20) {
+      this.chatHistory.splice(0, 2);
+    }
+
+    const streamBuffer = new StreamBuffer();
+
+    try {
+      const allData = getAllSheetData();
+      const stream = await generateResponseStream(text, allData, this.chatHistory);
+      const ttsService = getTTSService();
+
+      let fullResponseText = "";
+
+      for await (const chunk of stream) {
+        const chunkText = chunk.text();
+        fullResponseText += chunkText;
+
+        const sentences = streamBuffer.add(chunkText);
+        for (const sentence of sentences) {
+          await this.processSentence(socket, sentence, isVoiceInput, ttsService);
+        }
+      }
+
+      const remaining = streamBuffer.flush();
+      if (remaining) {
+        await this.processSentence(socket, remaining, isVoiceInput, ttsService);
+      }
+
+      this.chatHistory.push({
+        role: "model",
+        parts: [{ text: fullResponseText }],
+      });
+
+      socket.emit("response-complete");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("Error processing input:", message);
+      socket.emit("error", { message: "Internal server error occurred." });
+    }
+  }
+
+  private async processSentence(
+    socket: Socket,
+    sentence: string,
+    isVoiceInput: boolean,
+    ttsService: TTSService,
+  ): Promise<void> {
+    const uiText = stripTags(sentence);
+
+    if (isVoiceInput) {
+      socket.emit("audio-chunk", { type: "text", content: uiText });
+
+      try {
+        let ttsInput: string;
+        if (hasTags(sentence)) {
+          const innerText = sentence.replace(/<\/?speak>/g, "").trim();
+          ttsInput = `<speak>${removeMarkdownLinks(innerText)}</speak>`;
+        } else {
+          ttsInput = cleanupForTTS(sentence);
+        }
+
+        if (!ttsInput.trim() || !stripTags(ttsInput).trim()) return;
+
+        const audioStream: NodeJS.ReadableStream =
+          await ttsService.generateSpeechStream(ttsInput);
+
+        const chunks: Buffer[] = [];
+        audioStream.on("data", (chunk: Buffer) => {
+          chunks.push(chunk);
+        });
+
+        await new Promise((resolve, reject) => {
+          audioStream.on("end", () => {
+            const fullBuffer = Buffer.concat(chunks);
+            socket.emit("audio-chunk", { type: "audio", content: fullBuffer });
+            setTimeout(resolve, 50);
+          });
+          audioStream.on("error", (err) => {
+            console.error("[TTS] Stream error:", err);
+            reject(err);
+          });
+        });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        console.error("TTS Error:", message);
+      }
+    } else {
+      socket.emit("text-chunk", { content: uiText });
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Socket.io のハンドラとビジネスロジックを `server/services/chat.ts`（`ChatService`）に分離するリファクタリングです。

`claude/issue-209-20260611-1326` に積まれていたコミット `a9bbb4c` を `develop` から独立した形で cherry-pick しました。

## 変更内容

- `server/services/chat.ts` を新規作成し、Socket.io ハンドラのビジネスロジックを集約
- `server/index.ts` から該当ロジックを分離

closes #80

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbbWui6uVMR5v2xmV7vULj)_