### PR TITLE
feat: ウィジェットを Socket.io + Shadow DOM に移行しテキストストリーミング表示を実装 (#55)

### DIFF
--- a/widget/main.ts
+++ b/widget/main.ts
@@ -1,7 +1,7 @@
 import { initChatWidget } from './widget';
 
 initChatWidget({
-  apiEndpoint: '/api/chat',
+  serverUrl: window.location.origin,
   title: 'Chat Assistant',
   placeholder: 'Type a message...',
 });

--- a/widget/utils/socketHandler.ts
+++ b/widget/utils/socketHandler.ts
@@ -6,6 +6,7 @@ export interface SocketHandlerOptions {
   onAudioChunk: (data: { type: "text" | "audio"; content: unknown }) => void;
   onError: (message: string) => void;
   onConnect?: () => void;
+  onResponseComplete?: () => void;
 }
 
 export interface SocketHandler {
@@ -23,7 +24,7 @@ export interface SocketHandler {
 export function initSocketHandler(
   options: SocketHandlerOptions,
 ): SocketHandler {
-  const { serverUrl, onTextChunk, onAudioChunk, onError, onConnect } = options;
+  const { serverUrl, onTextChunk, onAudioChunk, onError, onConnect, onResponseComplete } = options;
 
   const socket: Socket = io(serverUrl);
 
@@ -44,6 +45,10 @@ export function initSocketHandler(
 
   socket.on("error", (data: { message: string }) => {
     onError(data.message);
+  });
+
+  socket.on("response-complete", () => {
+    onResponseComplete?.();
   });
 
   function sendUserInput(text: string, isVoiceInput: boolean): void {

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -1,201 +1,268 @@
-interface ChatMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
+import { initSocketHandler, SocketHandler } from './utils/socketHandler';
+import { initAudioHandler, AudioHandler } from './utils/audioHandler';
 
 interface WidgetConfig {
-  apiEndpoint?: string;
+  serverUrl?: string;
   title?: string;
   placeholder?: string;
 }
 
 export function initChatWidget(config: WidgetConfig = {}): void {
   const {
-    apiEndpoint = '/api/chat',
+    serverUrl = window.location.origin,
     title = 'Chat Assistant',
     placeholder = 'Type a message...',
   } = config;
 
-  // Create widget container
-  const container = document.createElement('div');
-  container.id = 'chat-widget-container';
-  container.style.cssText = `
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    width: 350px;
-    height: 500px;
-    display: flex;
-    flex-direction: column;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    overflow: hidden;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    font-family: sans-serif;
-    background: white;
-    z-index: 9999;
-  `;
+  // Shadow DOM for style isolation
+  const host = document.createElement('div');
+  host.id = 'makasete-ai-widget-host';
+  document.body.appendChild(host);
+  const shadow = host.attachShadow({ mode: 'open' });
 
-  // Header
-  const header = document.createElement('div');
-  header.style.cssText = `
-    background: #4f46e5;
-    color: white;
-    padding: 12px 16px;
-    font-weight: bold;
-    font-size: 16px;
-  `;
-  header.textContent = title;
-
-  // Messages area
-  const messagesArea = document.createElement('div');
-  messagesArea.style.cssText = `
-    flex: 1;
-    overflow-y: auto;
-    padding: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    background: #f9fafb;
-  `;
-
-  // Input area
-  const inputArea = document.createElement('div');
-  inputArea.style.cssText = `
-    display: flex;
-    padding: 8px;
-    border-top: 1px solid #e5e7eb;
-    background: white;
-    gap: 8px;
-  `;
-
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = placeholder;
-  input.style.cssText = `
-    flex: 1;
-    padding: 8px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 4px;
-    font-size: 14px;
-    outline: none;
-  `;
-
-  const sendButton = document.createElement('button');
-  sendButton.textContent = 'Send';
-  sendButton.style.cssText = `
-    padding: 8px 16px;
-    background: #4f46e5;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-  `;
-
-  inputArea.appendChild(input);
-  inputArea.appendChild(sendButton);
-
-  container.appendChild(header);
-  container.appendChild(messagesArea);
-  container.appendChild(inputArea);
-  document.body.appendChild(container);
-
-  const messages: ChatMessage[] = [];
-
-  function addMessageToUI(role: 'user' | 'assistant', content: string): HTMLDivElement {
-    const msgDiv = document.createElement('div');
-    msgDiv.style.cssText = `
+  // Styles
+  const style = document.createElement('style');
+  style.textContent = `
+    :host { all: initial; }
+    .container {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      width: 350px;
+      height: 500px;
+      display: flex;
+      flex-direction: column;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      font-family: sans-serif;
+      background: white;
+      z-index: 2147483647;
+    }
+    .header {
+      background: #4f46e5;
+      color: white;
+      padding: 12px 16px;
+      font-weight: bold;
+      font-size: 16px;
+      cursor: move;
+      user-select: none;
+    }
+    .messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      background: #f9fafb;
+    }
+    .msg {
       max-width: 80%;
       padding: 8px 12px;
       border-radius: 8px;
       font-size: 14px;
       line-height: 1.4;
       word-wrap: break-word;
-      ${role === 'user'
-        ? 'align-self: flex-end; background: #4f46e5; color: white; margin-left: auto;'
-        : 'align-self: flex-start; background: white; color: #111827; border: 1px solid #e5e7eb;'
-      }
-    `;
-    msgDiv.textContent = content;
-    messagesArea.appendChild(msgDiv);
+      white-space: pre-wrap;
+    }
+    .msg.user {
+      align-self: flex-end;
+      background: #4f46e5;
+      color: white;
+      margin-left: auto;
+    }
+    .msg.assistant {
+      align-self: flex-start;
+      background: white;
+      color: #111827;
+      border: 1px solid #e5e7eb;
+    }
+    .input-area {
+      display: flex;
+      padding: 8px;
+      border-top: 1px solid #e5e7eb;
+      background: white;
+      gap: 8px;
+    }
+    input[type="text"] {
+      flex: 1;
+      padding: 8px 12px;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      font-size: 14px;
+      outline: none;
+    }
+    input[type="text"]:disabled { background: #f3f4f6; }
+    button {
+      padding: 8px 16px;
+      background: #4f46e5;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:disabled { background: #a5b4fc; cursor: not-allowed; }
+    button.mic { background: #10b981; }
+    button.mic.recording { background: #ef4444; }
+  `;
+  shadow.appendChild(style);
+
+  // Container
+  const container = document.createElement('div');
+  container.className = 'container';
+
+  const header = document.createElement('div');
+  header.className = 'header';
+  header.textContent = title;
+
+  const messagesArea = document.createElement('div');
+  messagesArea.className = 'messages';
+
+  const inputArea = document.createElement('div');
+  inputArea.className = 'input-area';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = placeholder;
+
+  const sendBtn = document.createElement('button');
+  sendBtn.textContent = 'Send';
+
+  const micBtn = document.createElement('button');
+  micBtn.className = 'mic';
+  micBtn.textContent = '🎤';
+
+  inputArea.appendChild(input);
+  inputArea.appendChild(micBtn);
+  inputArea.appendChild(sendBtn);
+  container.appendChild(header);
+  container.appendChild(messagesArea);
+  container.appendChild(inputArea);
+  shadow.appendChild(container);
+
+  // --- Helpers ---
+
+  function addMessage(role: 'user' | 'assistant', text: string): HTMLDivElement {
+    const div = document.createElement('div');
+    div.className = `msg ${role}`;
+    div.textContent = text;
+    messagesArea.appendChild(div);
     messagesArea.scrollTop = messagesArea.scrollHeight;
-    return msgDiv;
+    return div;
   }
 
-  async function sendMessage(): Promise<void> {
-    const userText = input.value.trim();
-    if (!userText) return;
+  function setInputLocked(locked: boolean): void {
+    input.disabled = locked;
+    sendBtn.disabled = locked;
+  }
+
+  let currentAssistantDiv: HTMLDivElement | null = null;
+
+  // --- Audio ---
+  const audio: AudioHandler = initAudioHandler({
+    onTranscript: (text) => {
+      input.value = text;
+      sendMessage(true);
+    },
+    onRecordingEnd: () => {
+      micBtn.classList.remove('recording');
+    },
+  });
+
+  // --- Socket ---
+  const socket: SocketHandler = initSocketHandler({
+    serverUrl,
+    onTextChunk: (content) => {
+      if (!currentAssistantDiv) {
+        currentAssistantDiv = addMessage('assistant', '');
+      }
+      currentAssistantDiv.textContent += content;
+      messagesArea.scrollTop = messagesArea.scrollHeight;
+    },
+    onAudioChunk: (data) => {
+      if (data.type === 'text') {
+        if (!currentAssistantDiv) {
+          currentAssistantDiv = addMessage('assistant', '');
+        }
+        currentAssistantDiv.textContent += (data.content as string);
+        messagesArea.scrollTop = messagesArea.scrollHeight;
+      } else if (data.type === 'audio') {
+        audio.handleAudioChunk(data.content);
+      }
+    },
+    onError: (message) => {
+      addMessage('assistant', `Error: ${message}`);
+      setInputLocked(false);
+      currentAssistantDiv = null;
+    },
+    onResponseComplete: () => {
+      setInputLocked(false);
+      currentAssistantDiv = null;
+      input.focus();
+    },
+    onConnect: () => {
+      console.log('[MakaseteAI] Connected');
+    },
+  });
+
+  // --- Send ---
+  function sendMessage(isVoiceInput = false): void {
+    const text = input.value.trim();
+    if (!text) return;
 
     input.value = '';
-    sendButton.disabled = true;
+    setInputLocked(true);
+    currentAssistantDiv = null;
 
-    messages.push({ role: 'user', content: userText });
-    addMessageToUI('user', userText);
+    addMessage('user', text);
 
-    // Add a placeholder for the assistant response
-    const assistantDiv = addMessageToUI('assistant', '...');
-
-    try {
-      const response = await fetch(apiEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status}`);
-      }
-
-      if (!response.body) {
-        throw new Error('No response body');
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let assistantText = '';
-      assistantDiv.textContent = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        const chunk = decoder.decode(value, { stream: true });
-        const lines = chunk.split('\n');
-
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6).trim();
-            if (data === '[DONE]') continue;
-            try {
-              const parsed = JSON.parse(data);
-              if (parsed.text) {
-                assistantText += parsed.text;
-                assistantDiv.textContent = assistantText;
-                messagesArea.scrollTop = messagesArea.scrollHeight;
-              }
-            } catch {
-              // ignore parse errors for non-JSON lines
-            }
-          }
-        }
-      }
-
-      messages.push({ role: 'assistant', content: assistantText });
-    } catch (err) {
-      assistantDiv.textContent = 'Error: Could not get a response.';
-      assistantDiv.style.color = '#dc2626';
-      console.error('Chat widget error:', err);
-    } finally {
-      sendButton.disabled = false;
-      input.focus();
+    if (isVoiceInput) {
+      audio.resumeAudioContext();
+      audio.resetAudioState();
     }
+
+    socket.sendUserInput(text, isVoiceInput);
   }
 
-  sendButton.addEventListener('click', sendMessage);
+  sendBtn.addEventListener('click', () => sendMessage(false));
   input.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      sendMessage();
+    if (e.key === 'Enter') sendMessage(false);
+  });
+
+  micBtn.addEventListener('click', () => {
+    if (!audio.isSpeechRecognitionSupported()) {
+      alert('音声認識はこのブラウザでは利用できません');
+      return;
     }
+    audio.initAudioContext();
+    audio.toggleRecording();
+    micBtn.classList.toggle('recording');
+  });
+
+  // --- Drag ---
+  let isDragging = false;
+  let dragOffsetX = 0;
+  let dragOffsetY = 0;
+
+  header.addEventListener('mousedown', (e: MouseEvent) => {
+    isDragging = true;
+    const rect = container.getBoundingClientRect();
+    dragOffsetX = e.clientX - rect.left;
+    dragOffsetY = e.clientY - rect.top;
+  });
+
+  document.addEventListener('mousemove', (e: MouseEvent) => {
+    if (!isDragging) return;
+    container.style.right = 'auto';
+    container.style.bottom = 'auto';
+    container.style.left = `${e.clientX - dragOffsetX}px`;
+    container.style.top = `${e.clientY - dragOffsetY}px`;
+  });
+
+  document.addEventListener('mouseup', () => {
+    isDragging = false;
   });
 }


### PR DESCRIPTION
## 概要

ウィジェットを Socket.io + Shadow DOM に移行し、テキスト生成のストリーミング表示を実装します。

`claude/issue-209-20260611-1326` に積まれていたコミット `f7d3529` を `develop` から独立した形で cherry-pick しました（#80 には非依存であることを確認済み）。

## 変更内容

- ウィジェットの Socket.io + Shadow DOM 化
- 句読点ベースのテキストストリーミング表示

closes #55

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbbWui6uVMR5v2xmV7vULj)_