### PR TITLE
fix: チャットウィジェットのUIを元のリッチUIに戻す (Issue #85)

### DIFF
--- a/widget/main.ts
+++ b/widget/main.ts
@@ -1,7 +1,6 @@
-import { initChatWidget } from './widget';
+import { initChatWidget } from "./widget";
 
 initChatWidget({
   serverUrl: window.location.origin,
-  title: 'Chat Assistant',
-  placeholder: 'Type a message...',
+  language: "ja",
 });

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -28,7 +28,7 @@ const socketHandler = {
 const audioHandler = {
     handleAudioChunk: vi.fn(),
     initAudioContext: vi.fn(),
-    resumeAudioContext: vi.fn(),
+    resumeAudioContext: vi.fn(() => Promise.resolve()),
     resetAudioState: vi.fn(),
     toggleRecording: vi.fn(),
     isSpeechRecognitionSupported: vi.fn(() => true),
@@ -55,46 +55,74 @@ function getEls() {
     const shadow = host.shadowRoot!;
     return {
         shadow,
-        container: shadow.querySelector('.container') as HTMLElement,
-        header: shadow.querySelector('.header') as HTMLElement,
-        messages: shadow.querySelector('.messages') as HTMLElement,
-        input: shadow.querySelector('input[type="text"]') as HTMLInputElement,
-        sendBtn: Array.from(shadow.querySelectorAll('button')).find((b) => b.textContent === 'Send') as HTMLButtonElement,
-        micBtn: shadow.querySelector('button.mic') as HTMLButtonElement,
+        container: shadow.querySelector('.widget-container') as HTMLElement,
+        chatWindow: shadow.querySelector('.chat-window') as HTMLElement,
+        chatTitle: shadow.querySelector('.chat-title') as HTMLElement,
+        header: shadow.querySelector('.chat-header') as HTMLElement,
+        timeline: shadow.querySelector('.chat-timeline') as HTMLElement,
+        input: shadow.querySelector('.text-input') as HTMLTextAreaElement,
+        sendBtn: shadow.querySelector('.send-btn') as HTMLButtonElement,
+        micBtn: shadow.querySelector('.mic-btn') as HTMLButtonElement,
+        launcherBtn: shadow.querySelector('.launcher-button') as HTMLButtonElement,
+        closeBtn: shadow.querySelector('.close-btn') as HTMLButtonElement,
+        loadingOverlay: shadow.querySelector('.loading-overlay') as HTMLElement,
     };
 }
 
-describe('initChatWidget', () => {
+describe('initChatWidget (rich UI)', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
+        document.body.style.overflow = '';
         vi.clearAllMocks();
         audioHandler.isSpeechRecognitionSupported.mockReturnValue(true);
+        audioHandler.resumeAudioContext.mockReturnValue(Promise.resolve());
         window.alert = vi.fn();
+        // fetch(/health) はローディング解除に使われる
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)));
     });
 
-    it('should mount a shadow-dom widget with the configured title and placeholder', () => {
+    it('should mount the launcher and chat window with the configured title and placeholder', () => {
         initChatWidget({ title: 'My Bot', placeholder: 'Ask...' });
-        const { header, input } = getEls();
-        expect(header.textContent).toBe('My Bot');
+        const { launcherBtn, chatWindow, chatTitle, input } = getEls();
+        expect(launcherBtn).toBeTruthy();
+        expect(chatWindow).toBeTruthy();
+        expect(chatTitle.textContent).toBe('My Bot');
         expect(input.placeholder).toBe('Ask...');
     });
 
-    it('should use sensible defaults when no config is given', () => {
+    it('should use Japanese defaults when no config is given', () => {
         initChatWidget();
-        const { header } = getEls();
-        expect(header.textContent).toBe('Chat Assistant');
+        const { chatTitle, input } = getEls();
+        expect(chatTitle.textContent).toBe('AIアシスタント');
+        expect(input.placeholder).toBe('質問を入力...');
     });
 
-    it('should send a message on send-button click and lock the input', () => {
+    it('should render the initial greeting message', () => {
+        initChatWidget();
+        const { timeline } = getEls();
+        const greeting = timeline.querySelector('.message.makasete-server');
+        expect(greeting?.innerHTML).toContain('AIアシスタント');
+    });
+
+    it('should open and close the chat window via the launcher and close button', () => {
+        initChatWidget();
+        const { launcherBtn, chatWindow, closeBtn } = getEls();
+        expect(chatWindow.classList.contains('open')).toBe(false);
+        launcherBtn.click();
+        expect(chatWindow.classList.contains('open')).toBe(true);
+        closeBtn.click();
+        expect(chatWindow.classList.contains('open')).toBe(false);
+    });
+
+    it('should send a message on send-button click', () => {
         initChatWidget({ language: 'ja' });
-        const { input, sendBtn, messages } = getEls();
+        const { input, sendBtn, timeline } = getEls();
         input.value = 'hello';
         sendBtn.click();
 
         expect(socketHandler.sendUserInput).toHaveBeenCalledWith('hello', false, 'ja');
         expect(input.value).toBe('');
-        expect(input.disabled).toBe(true);
-        expect(messages.querySelector('.msg.user')?.textContent).toBe('hello');
+        expect(timeline.querySelector('.message.user')?.innerHTML).toBe('hello');
     });
 
     it('should ignore empty sends', () => {
@@ -105,61 +133,68 @@ describe('initChatWidget', () => {
         expect(socketHandler.sendUserInput).not.toHaveBeenCalled();
     });
 
-    it('should send on Enter key', () => {
+    it('should send on Cmd/Ctrl + Enter only', () => {
         initChatWidget();
         const { input } = getEls();
         input.value = 'hi';
         input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(socketHandler.sendUserInput).not.toHaveBeenCalled();
+
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }));
         expect(socketHandler.sendUserInput).toHaveBeenCalledWith('hi', false, 'ja');
     });
 
-    it('should not send on other keys', () => {
+    it('should toggle send/mic buttons based on input text', () => {
         initChatWidget();
-        const { input } = getEls();
-        input.value = 'hi';
-        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
-        expect(socketHandler.sendUserInput).not.toHaveBeenCalled();
+        const { input, sendBtn, micBtn } = getEls();
+        input.value = 'typing';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        expect(sendBtn.style.display).toBe('flex');
+        expect(micBtn.style.display).toBe('none');
+
+        input.value = '';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        expect(sendBtn.style.display).toBe('none');
+        expect(micBtn.style.display).toBe('flex');
     });
 
     describe('socket callbacks', () => {
-        it('onTextChunk should append streaming text to an assistant message', () => {
+        it('onTextChunk should stream-append into a new server message after the user sends', () => {
             initChatWidget();
-            const { messages } = getEls();
+            const { input, sendBtn, timeline } = getEls();
+            input.value = 'q';
+            sendBtn.click();
             captured.socketOpts!.onTextChunk('Hel');
             captured.socketOpts!.onTextChunk('lo');
-            const assistant = messages.querySelector('.msg.assistant');
-            expect(assistant?.textContent).toBe('Hello');
+            const msgs = timeline.querySelectorAll('.message.makasete-server');
+            // 挨拶 + 応答1件、最後がストリーミングされた応答
+            expect(msgs[msgs.length - 1].innerHTML).toBe('Hello');
         });
 
-        it('onAudioChunk text should append text, audio should forward to the audio handler', () => {
+        it('onAudioChunk text appends text and audio forwards to the audio handler', () => {
             initChatWidget();
+            const { input, sendBtn, timeline } = getEls();
+            input.value = 'q';
+            sendBtn.click();
             captured.socketOpts!.onAudioChunk({ type: 'text', content: 'spoken' });
-            const { messages } = getEls();
-            expect(messages.querySelector('.msg.assistant')?.textContent).toBe('spoken');
+            const msgs = timeline.querySelectorAll('.message.makasete-server');
+            expect(msgs[msgs.length - 1].innerHTML).toBe('spoken');
 
             captured.socketOpts!.onAudioChunk({ type: 'audio', content: new ArrayBuffer(4) });
             expect(audioHandler.handleAudioChunk).toHaveBeenCalled();
         });
 
-        it('onError should render an error message and unlock the input', () => {
+        it('onError should render an error message', () => {
             initChatWidget();
-            const { input, messages } = getEls();
-            input.disabled = true;
+            const { timeline } = getEls();
             captured.socketOpts!.onError('boom');
-            expect(messages.querySelector('.msg.assistant')?.textContent).toBe('Error: boom');
-            expect(input.disabled).toBe(false);
+            const msgs = timeline.querySelectorAll('.message.makasete-server');
+            expect(msgs[msgs.length - 1].innerHTML).toContain('boom');
         });
 
-        it('onResponseComplete should unlock the input', () => {
+        it('onResponseComplete and onConnect should not throw', () => {
             initChatWidget();
-            const { input } = getEls();
-            input.disabled = true;
-            captured.socketOpts!.onResponseComplete!();
-            expect(input.disabled).toBe(false);
-        });
-
-        it('onConnect should not throw', () => {
-            initChatWidget();
+            expect(() => captured.socketOpts!.onResponseComplete!()).not.toThrow();
             expect(() => captured.socketOpts!.onConnect!()).not.toThrow();
         });
     });
@@ -185,15 +220,16 @@ describe('initChatWidget', () => {
             initChatWidget();
             const { micBtn } = getEls();
             micBtn.click();
-            expect(audioHandler.initAudioContext).toHaveBeenCalled();
             expect(audioHandler.toggleRecording).toHaveBeenCalled();
             expect(micBtn.classList.contains('recording')).toBe(true);
         });
 
-        it('mic click should alert when speech recognition is unsupported', () => {
+        it('mic should be hidden and alerted when speech recognition is unsupported', () => {
             audioHandler.isSpeechRecognitionSupported.mockReturnValue(false);
             initChatWidget();
-            const { micBtn } = getEls();
+            const { micBtn, sendBtn } = getEls();
+            expect(micBtn.style.display).toBe('none');
+            expect(sendBtn.style.display).toBe('flex');
             micBtn.click();
             expect(window.alert).toHaveBeenCalled();
             expect(audioHandler.toggleRecording).not.toHaveBeenCalled();
@@ -201,22 +237,20 @@ describe('initChatWidget', () => {
     });
 
     describe('drag', () => {
-        it('should reposition the container while dragging', () => {
+        it('should reposition the container while dragging the header', () => {
             initChatWidget();
             const { header, container } = getEls();
+            // ドラッグはデスクトップ幅でのみ有効
+            vi.stubGlobal('innerWidth', 1024);
 
             header.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 10, bubbles: true }));
             document.dispatchEvent(new MouseEvent('mousemove', { clientX: 60, clientY: 70, bubbles: true }));
 
-            // offset = mousedown座標 - rect.left(=0)。left = clientX - offset = 60 - 10 = 50
             expect(container.style.left).toBe('50px');
             expect(container.style.top).toBe('60px');
             expect(container.style.right).toBe('auto');
 
             document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
-            // mouseup 後は移動しない
-            document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 200, bubbles: true }));
-            expect(container.style.left).toBe('50px');
         });
     });
 });

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -1,271 +1,257 @@
-import { initSocketHandler, SocketHandler } from './utils/socketHandler';
-import { initAudioHandler, AudioHandler } from './utils/audioHandler';
+import widgetStyles from "./styles.css?inline";
+import { initSocketHandler, SocketHandler } from "./utils/socketHandler";
+import { initAudioHandler, AudioHandler } from "./utils/audioHandler";
+import { initDragHandler } from "./utils/dragHandler";
+import {
+  getUIElements,
+  updateInputActions,
+  showTypingIndicator,
+  appendMessage,
+  hideLoadingOverlay,
+  MessageState,
+} from "./utils/uiRenderer";
 
 interface WidgetConfig {
   serverUrl?: string;
   title?: string;
   placeholder?: string;
-  language?: 'ja' | 'en';
+  language?: "ja" | "en";
+}
+
+/** ウィジェットのリッチUIマークアップ（ランチャーボタン・チャットウィンドウ等） */
+function buildWidgetMarkup(placeholder: string, helperText: string): string {
+  return `
+    <div class="widget-container">
+      <div class="chat-window">
+        <div class="chat-header">
+          <span class="chat-title"></span>
+          <div class="header-controls">
+            <button class="close-btn" title="閉じる">
+              <svg class="lucide lucide-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="chat-timeline"></div>
+        <div class="input-area">
+          <div class="input-wrapper">
+            <textarea class="text-input" placeholder="${placeholder}" rows="1"></textarea>
+            <div class="input-helper">${helperText}</div>
+          </div>
+          <div class="input-actions">
+            <button class="btn mic-btn" title="音声入力">
+              <svg class="lucide lucide-mic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>
+            </button>
+            <button class="btn send-btn" title="送信" style="display: none;">
+              <svg class="lucide lucide-send" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="widget-footer">Powered by Makasete AI</div>
+        <div class="loading-overlay">
+          <div class="spinner"></div>
+          <div class="loading-text">準備中です。少々お待ちください...</div>
+        </div>
+      </div>
+      <button class="launcher-button" title="AIアシスタントに相談する">
+        <svg class="launcher-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 8V4H8"></path>
+          <rect width="16" height="12" x="4" y="8" rx="2"></rect>
+          <path d="M2 14h2"></path>
+          <path d="M20 14h2"></path>
+          <path d="M15 13v2"></path>
+          <path d="M9 13v2"></path>
+        </svg>
+      </button>
+    `;
 }
 
 export function initChatWidget(config: WidgetConfig = {}): void {
   const {
     serverUrl = window.location.origin,
-    title = 'Chat Assistant',
-    placeholder = 'Type a message...',
-    language = 'ja',
+    title = "AIアシスタント",
+    placeholder = "質問を入力...",
+    language = "ja",
   } = config;
 
-  // Shadow DOM for style isolation
-  const host = document.createElement('div');
-  host.id = 'makasete-ai-widget-host';
-  document.body.appendChild(host);
-  const shadow = host.attachShadow({ mode: 'open' });
+  const isEn = language === "en";
+  const helperText = isEn ? "Cmd(Ctrl) + Enter to send" : "Command(Ctrl) + Enterで送信";
+  const greeting = isEn
+    ? "Hi, I'm your AI assistant. How can I help you?"
+    : "AIアシスタントです。何かお手伝いできることはありますか？";
 
-  // Styles
-  const style = document.createElement('style');
-  style.textContent = `
-    :host { all: initial; }
-    .container {
-      position: fixed;
-      bottom: 20px;
-      right: 20px;
-      width: 350px;
-      height: 500px;
-      display: flex;
-      flex-direction: column;
-      border: 1px solid #ccc;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-      font-family: sans-serif;
-      background: white;
-      z-index: 2147483647;
-    }
-    .header {
-      background: #4f46e5;
-      color: white;
-      padding: 12px 16px;
-      font-weight: bold;
-      font-size: 16px;
-      cursor: move;
-      user-select: none;
-    }
-    .messages {
-      flex: 1;
-      overflow-y: auto;
-      padding: 12px;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      background: #f9fafb;
-    }
-    .msg {
-      max-width: 80%;
-      padding: 8px 12px;
-      border-radius: 8px;
-      font-size: 14px;
-      line-height: 1.4;
-      word-wrap: break-word;
-      white-space: pre-wrap;
-    }
-    .msg.user {
-      align-self: flex-end;
-      background: #4f46e5;
-      color: white;
-      margin-left: auto;
-    }
-    .msg.assistant {
-      align-self: flex-start;
-      background: white;
-      color: #111827;
-      border: 1px solid #e5e7eb;
-    }
-    .input-area {
-      display: flex;
-      padding: 8px;
-      border-top: 1px solid #e5e7eb;
-      background: white;
-      gap: 8px;
-    }
-    input[type="text"] {
-      flex: 1;
-      padding: 8px 12px;
-      border: 1px solid #d1d5db;
-      border-radius: 4px;
-      font-size: 14px;
-      outline: none;
-    }
-    input[type="text"]:disabled { background: #f3f4f6; }
-    button {
-      padding: 8px 16px;
-      background: #4f46e5;
-      color: white;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      font-size: 14px;
-    }
-    button:disabled { background: #a5b4fc; cursor: not-allowed; }
-    button.mic { background: #10b981; }
-    button.mic.recording { background: #ef4444; }
-  `;
+  // Shadow DOM for style isolation
+  const host = document.createElement("div");
+  host.id = "makasete-ai-widget-host";
+  document.body.appendChild(host);
+  const shadow = host.attachShadow({ mode: "open" });
+
+  const style = document.createElement("style");
+  style.textContent = widgetStyles;
   shadow.appendChild(style);
 
-  // Container
-  const container = document.createElement('div');
-  container.className = 'container';
-
-  const header = document.createElement('div');
-  header.className = 'header';
-  header.textContent = title;
-
-  const messagesArea = document.createElement('div');
-  messagesArea.className = 'messages';
-
-  const inputArea = document.createElement('div');
-  inputArea.className = 'input-area';
-
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = placeholder;
-
-  const sendBtn = document.createElement('button');
-  sendBtn.textContent = 'Send';
-
-  const micBtn = document.createElement('button');
-  micBtn.className = 'mic';
-  micBtn.textContent = '🎤';
-
-  inputArea.appendChild(input);
-  inputArea.appendChild(micBtn);
-  inputArea.appendChild(sendBtn);
-  container.appendChild(header);
-  container.appendChild(messagesArea);
-  container.appendChild(inputArea);
-  shadow.appendChild(container);
-
-  // --- Helpers ---
-
-  function addMessage(role: 'user' | 'assistant', text: string): HTMLDivElement {
-    const div = document.createElement('div');
-    div.className = `msg ${role}`;
-    div.textContent = text;
-    messagesArea.appendChild(div);
-    messagesArea.scrollTop = messagesArea.scrollHeight;
-    return div;
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = buildWidgetMarkup(placeholder, helperText);
+  // innerHTML を直接 shadow に展開する（widget-container を維持）
+  while (wrapper.firstChild) {
+    shadow.appendChild(wrapper.firstChild);
   }
 
-  function setInputLocked(locked: boolean): void {
-    input.disabled = locked;
-    sendBtn.disabled = locked;
-  }
+  const els = getUIElements(shadow);
+  els.chatTitle.textContent = title;
 
-  let currentAssistantDiv: HTMLDivElement | null = null;
+  const messageState: MessageState = { currentMakaseteServerMessageRaw: "" };
+
+  // ボットの音声出力が有効かどうか（マイク利用時に自動で有効化される）
+  let isAudioEnabled = false;
+  // ドラッグ操作中かどうか（ランチャーのクリック判定で使用）
+  let isDragging = false;
 
   // --- Audio ---
   const audio: AudioHandler = initAudioHandler({
     onTranscript: (text) => {
-      input.value = text;
+      els.input.value = text;
       sendMessage(true);
     },
     onRecordingEnd: () => {
-      micBtn.classList.remove('recording');
+      els.micBtn.classList.remove("recording");
     },
     language,
   });
+
+  // 音声認識が使えない環境ではマイクボタンを隠し、送信ボタンを常時表示する
+  if (!audio.isSpeechRecognitionSupported()) {
+    els.micBtn.style.display = "none";
+    els.sendBtn.style.display = "flex";
+  }
 
   // --- Socket ---
   const socket: SocketHandler = initSocketHandler({
     serverUrl,
     onTextChunk: (content) => {
-      if (!currentAssistantDiv) {
-        currentAssistantDiv = addMessage('assistant', '');
-      }
-      currentAssistantDiv.textContent += content;
-      messagesArea.scrollTop = messagesArea.scrollHeight;
+      appendMessage(els.timeline, messageState, "makasete-server", content, true);
     },
     onAudioChunk: (data) => {
-      if (data.type === 'text') {
-        if (!currentAssistantDiv) {
-          currentAssistantDiv = addMessage('assistant', '');
-        }
-        currentAssistantDiv.textContent += (data.content as string);
-        messagesArea.scrollTop = messagesArea.scrollHeight;
-      } else if (data.type === 'audio') {
+      if (data.type === "text") {
+        appendMessage(
+          els.timeline,
+          messageState,
+          "makasete-server",
+          data.content as string,
+          true,
+        );
+      } else if (data.type === "audio") {
         audio.handleAudioChunk(data.content);
       }
     },
     onError: (message) => {
-      addMessage('assistant', `Error: ${message}`);
-      setInputLocked(false);
-      currentAssistantDiv = null;
+      const prefix = isEn ? "An error occurred: " : "エラーが発生しました: ";
+      appendMessage(
+        els.timeline,
+        messageState,
+        "makasete-server",
+        `${prefix}${message}`,
+      );
     },
     onResponseComplete: () => {
-      setInputLocked(false);
-      currentAssistantDiv = null;
-      input.focus();
+      els.input.focus();
     },
     onConnect: () => {
-      console.log('[MakaseteAI] Connected');
+      console.log("[MakaseteAI] Connected");
     },
   });
 
   // --- Send ---
   function sendMessage(isVoiceInput = false): void {
-    const text = input.value.trim();
+    const text = els.input.value.trim();
     if (!text) return;
 
-    input.value = '';
-    setInputLocked(true);
-    currentAssistantDiv = null;
+    const useAudio = isVoiceInput || isAudioEnabled;
 
-    addMessage('user', text);
+    appendMessage(els.timeline, messageState, "user", text);
+    els.input.value = "";
+    updateInputActions(els.input, els.sendBtn, els.micBtn);
+    showTypingIndicator(els.timeline);
 
-    if (isVoiceInput) {
-      audio.resumeAudioContext();
+    if (useAudio) {
       audio.resetAudioState();
+      audio.resumeAudioContext().catch(console.error);
     }
 
-    socket.sendUserInput(text, isVoiceInput, language);
+    socket.sendUserInput(text, useAudio, language);
   }
 
-  sendBtn.addEventListener('click', () => sendMessage(false));
-  input.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.key === 'Enter') sendMessage(false);
+  // --- Events ---
+  els.sendBtn.addEventListener("click", () => {
+    audio.resumeAudioContext().catch(console.error);
+    sendMessage();
   });
 
-  micBtn.addEventListener('click', () => {
+  els.input.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      audio.resumeAudioContext().catch(console.error);
+      sendMessage();
+    }
+  });
+
+  els.input.addEventListener("input", () => {
+    updateInputActions(els.input, els.sendBtn, els.micBtn);
+  });
+
+  els.micBtn.addEventListener("click", () => {
     if (!audio.isSpeechRecognitionSupported()) {
-      alert('音声認識はこのブラウザでは利用できません');
+      alert(isEn ? "Speech recognition is not available in this browser." : "音声認識はこのブラウザでは利用できません");
       return;
     }
+    audio.resumeAudioContext().catch(console.error);
     audio.initAudioContext();
     audio.toggleRecording();
-    micBtn.classList.toggle('recording');
+    const recording = els.micBtn.classList.toggle("recording");
+    // マイク利用開始時にボットの音声出力も自動で有効化する
+    if (recording) isAudioEnabled = true;
   });
+
+  els.launcherBtn.addEventListener("click", () => {
+    if (isDragging) return; // ドラッグ中はトグルしない
+    const isOpen = els.chatWindow.classList.toggle("open");
+
+    // モバイルでは開いている間 body のスクロールを止める
+    if (window.innerWidth <= 600) {
+      document.body.style.overflow = isOpen ? "hidden" : "";
+    }
+
+    if (isOpen) {
+      audio.resumeAudioContext().catch(console.error);
+    } else {
+      audio.resetAudioState();
+    }
+  });
+
+  if (els.closeBtn) {
+    els.closeBtn.addEventListener("click", () => {
+      els.chatWindow.classList.remove("open");
+      document.body.style.overflow = "";
+      audio.resetAudioState();
+    });
+  }
 
   // --- Drag ---
-  let isDragging = false;
-  let dragOffsetX = 0;
-  let dragOffsetY = 0;
-
-  header.addEventListener('mousedown', (e: MouseEvent) => {
-    isDragging = true;
-    const rect = container.getBoundingClientRect();
-    dragOffsetX = e.clientX - rect.left;
-    dragOffsetY = e.clientY - rect.top;
+  const header = shadow.querySelector(".chat-header") as HTMLElement;
+  initDragHandler(els.container, [els.launcherBtn, header], els.launcherBtn, (dragging) => {
+    isDragging = dragging;
   });
 
-  document.addEventListener('mousemove', (e: MouseEvent) => {
-    if (!isDragging) return;
-    container.style.right = 'auto';
-    container.style.bottom = 'auto';
-    container.style.left = `${e.clientX - dragOffsetX}px`;
-    container.style.top = `${e.clientY - dragOffsetY}px`;
-  });
+  // --- データ準備の完了を待ってローディングを解除 ---
+  fetch(`${serverUrl}/health`)
+    .then((response) => {
+      if (response.ok) {
+        hideLoadingOverlay(els.loadingOverlay);
+      }
+    })
+    .catch((e) => {
+      console.error("[MakaseteAI] Error waiting for data:", e);
+    });
 
-  document.addEventListener('mouseup', () => {
-    isDragging = false;
-  });
+  // 初回の挨拶メッセージ
+  appendMessage(els.timeline, messageState, "makasete-server", greeting);
 }


### PR DESCRIPTION
## 概要

チャットウィジェットのUIが、以前のリッチなUIから簡素な常時表示UIに変わってしまっていた問題を修正します。**UIのみ**を元に戻し、機能面（Socket.io通信・音声処理・多言語対応）は現状を維持しています。

## 原因

調査の結果、UIが変わったのは Issue #85 のリファクタそのものではなく、その後の Socket.io + Shadow DOM 移行（Issue #55, commit `a72f178`）でした。

- Issue #85 のリファクタでは `uiRenderer.ts` / `dragHandler.ts` といったモジュールが **リッチUI構造を前提に** 作られていた（`.launcher-button`, `.chat-window`, `.close-btn`, タイピングインジケーター, ローディングオーバーレイ等）。
- ところが Socket.io 移行で `widget.ts` / `main.ts` が **これらのモジュールを使わない簡素なUI**（常時表示の固定ボックス、`Send` テキストボタン、`🎤` 絵文字ボタン）に置き換わり、リッチUI向けモジュールと `styles.css` が孤立していた。

## 変更内容

`widget.ts` / `main.ts` を書き換え、既存の孤立モジュール（`uiRenderer`, `dragHandler`, `text`）と `styles.css` を使って元のリッチUIを復元しました。

復元したUI要素:
- フローティングのランチャーボタン（FAB）と開閉式チャットウィンドウ
- ヘッダー（タイトル + 閉じるボタン）と lucide アイコン
- 入力テキストの有無で切り替わる 送信 / マイク ボタン
- タイピングインジケーター・ローディングオーバーレイ・フッター
- モバイルでの全画面表示、ドラッグによる移動
- Markdown リンクのレンダリング（XSS エスケープ込み）

維持した機能面:
- Socket.io イベント契約（`text-chunk` / `audio-chunk` / `error` / `response-complete`、`user-input` 送信）
- `socketHandler` / `audioHandler` モジュールおよび音声処理
- 多言語対応（`language` パラメータ）

## テスト

- `widget.test.ts` を復元後のリッチUIに合わせて書き換え
- `pnpm typecheck` / `pnpm lint` / `pnpm test`（130 件）すべてパス
- `vite build` でバンドル生成を確認（`styles.css` がインライン化されることを確認）

closes #85


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGEyMmwPmNuBedBZWaLTsa)_