### PR TITLE
test: フロント/バックエンドのカバレッジを個別に80%以上で強制

### DIFF
--- a/server/services/sheets.test.ts
+++ b/server/services/sheets.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
 import { mapRowsToObjects, getAllSheetData, getInternalSheetData, fetchAllSheets, getSystemPrompt } from './sheets';
 import { google } from 'googleapis';
 import { config } from '../config';
@@ -199,6 +200,82 @@ describe('sheets service utilities', () => {
             await expect(fetchAllSheets()).resolves.toBeUndefined();
             expect(errSpy).toHaveBeenCalled();
             errSpy.mockRestore();
+        });
+    });
+
+    describe('getSheetsClient authentication resolution', () => {
+        // getSheetsClient は内部関数なので fetchAllSheets 経由で認証分岐を検証する。
+        beforeEach(() => {
+            vi.clearAllMocks();
+            config.googleSheetsId = 'test-id';
+            delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+            delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        });
+
+        // メタデータ取得だけ成功させ、シートが無い状態で早期に完了させる。
+        function stubEmptySpreadsheet() {
+            const sheets = google.sheets({ version: 'v4' });
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (sheets.spreadsheets.get as any).mockResolvedValue({ data: { sheets: [] } });
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function lastAuthOptions(): any {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const calls = (google.auth.GoogleAuth as any).mock.calls;
+            return calls[calls.length - 1][0];
+        }
+
+        it('uses GOOGLE_APPLICATION_CREDENTIALS when the env var is set', async () => {
+            process.env.GOOGLE_APPLICATION_CREDENTIALS = '/secrets/creds.json';
+            const existsSpy = vi.spyOn(fs, 'existsSync');
+            stubEmptySpreadsheet();
+
+            await fetchAllSheets();
+
+            expect(lastAuthOptions().keyFile).toBe('/secrets/creds.json');
+            // env var が優先されるためローカルキーは参照されない。
+            expect(existsSpy).not.toHaveBeenCalled();
+        });
+
+        it('falls back to a non-empty local key file', async () => {
+            vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn(fs, 'statSync').mockReturnValue({ size: 128 } as any);
+            stubEmptySpreadsheet();
+
+            await fetchAllSheets();
+
+            expect(lastAuthOptions().keyFile).toContain('google-key.json');
+        });
+
+        it('ignores an empty local key file', async () => {
+            vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn(fs, 'statSync').mockReturnValue({ size: 0 } as any);
+            stubEmptySpreadsheet();
+
+            await fetchAllSheets();
+
+            expect(lastAuthOptions().keyFile).toBeUndefined();
+        });
+
+        it('warns and continues when the local key file cannot be read', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+            vi.spyOn(fs, 'statSync').mockImplementation(() => {
+                throw new Error('EACCES');
+            });
+            stubEmptySpreadsheet();
+
+            await fetchAllSheets();
+
+            expect(warnSpy).toHaveBeenCalled();
+            expect(lastAuthOptions().keyFile).toBeUndefined();
         });
     });
 });

--- a/server/services/tts/elevenlabs.test.ts
+++ b/server/services/tts/elevenlabs.test.ts
@@ -51,6 +51,27 @@ describe('ElevenLabsTTSService', () => {
         expect(Buffer.concat(chunks).toString()).toBe('chunk1chunk2');
     });
 
+    it('should fall back to default voice and model IDs when config values are empty', async () => {
+        const originalVoice = config.voiceId;
+        const originalModel = config.modelId;
+        config.voiceId = '';
+        config.modelId = '';
+        convert.mockResolvedValue((async function* () {
+            yield Buffer.from('x');
+        })());
+
+        const svc = new ElevenLabsTTSService();
+        await svc.generateSpeechStream('hello');
+
+        expect(convert).toHaveBeenCalledWith(
+            'AYFJOmHxRJdmf572TQ7R',
+            expect.objectContaining({ modelId: 'eleven_flash_v2_5' }),
+        );
+
+        config.voiceId = originalVoice;
+        config.modelId = originalModel;
+    });
+
     it('should rethrow and log when the client fails', async () => {
         const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         convert.mockRejectedValue(new Error('api down'));

--- a/server/services/tts/google.test.ts
+++ b/server/services/tts/google.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
 
 const { synthesize, GoogleAuth, texttospeech } = vi.hoisted(() => {
     const synthesize = vi.fn();
@@ -27,8 +28,54 @@ describe('GeminiTTSService', () => {
         delete process.env.K_SERVICE;
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        delete process.env.K_SERVICE;
+    });
+
+    // 認証情報の解決分岐（env var / ローカルキー / Cloud Run）を検証する。
+    const okAudio = (_req: unknown, cb: (e: unknown, r: unknown) => void) =>
+        cb(null, { data: { audioContent: Buffer.from('x').toString('base64') } });
+
     it('should expose its name', () => {
         expect(new GeminiTTSService().getName()).toBe('gemini-tts');
+    });
+
+    it('should use GOOGLE_APPLICATION_CREDENTIALS when the env var is set', async () => {
+        process.env.GOOGLE_APPLICATION_CREDENTIALS = '/secrets/creds.json';
+        synthesize.mockImplementation(okAudio);
+
+        await new GeminiTTSService().generateSpeechStream('hi');
+
+        expect(GoogleAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ keyFile: '/secrets/creds.json' }),
+        );
+    });
+
+    it('should fall back to a local key file when present', async () => {
+        vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+        synthesize.mockImplementation(okAudio);
+
+        await new GeminiTTSService().generateSpeechStream('hi');
+
+        expect(GoogleAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ keyFile: expect.stringContaining('google-key.json') }),
+        );
+    });
+
+    it('should not warn on Cloud Run (K_SERVICE set) when no credentials are found', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.K_SERVICE = 'makasete-service';
+        vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+        synthesize.mockImplementation(okAudio);
+
+        await new GeminiTTSService().generateSpeechStream('hi');
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(GoogleAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ keyFile: undefined }),
+        );
     });
 
     it('should synthesize plain text and return a readable stream of decoded audio', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,10 +19,25 @@ export default defineConfig({
         "widget/vite.config.ts",
       ],
       thresholds: {
+        // 全体（フロント + バック合算）の下限
         statements: 80,
         branches: 80,
         functions: 80,
         lines: 80,
+        // バックエンド（server/）単体で 80% 以上を保証する
+        "server/**": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+        // フロントエンド（widget/）単体で 80% 以上を保証する
+        "widget/**": {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
       },
     },
   },

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 interface CapturedSocketOpts {
     serverUrl: string;
@@ -81,6 +81,11 @@ describe('initChatWidget (rich UI)', () => {
         vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)));
     });
 
+    afterEach(() => {
+        // stubGlobal(innerWidth / fetch) のテスト間汚染を防ぐ
+        vi.unstubAllGlobals();
+    });
+
     it('should mount the launcher and chat window with the configured title and placeholder', () => {
         initChatWidget({ title: 'My Bot', placeholder: 'Ask...' });
         const { launcherBtn, chatWindow, chatTitle, input } = getEls();
@@ -123,6 +128,33 @@ describe('initChatWidget (rich UI)', () => {
         expect(socketHandler.sendUserInput).toHaveBeenCalledWith('hello', false, 'ja');
         expect(input.value).toBe('');
         expect(timeline.querySelector('.message.user')?.innerHTML).toBe('hello');
+    });
+
+    it('should lock body scroll on mobile when opening and restore it when closing via the launcher', () => {
+        vi.stubGlobal('innerWidth', 500);
+        initChatWidget();
+        const { launcherBtn, chatWindow } = getEls();
+
+        launcherBtn.click(); // open
+        expect(chatWindow.classList.contains('open')).toBe(true);
+        expect(document.body.style.overflow).toBe('hidden');
+
+        launcherBtn.click(); // close via launcher
+        expect(chatWindow.classList.contains('open')).toBe(false);
+        expect(document.body.style.overflow).toBe('');
+        expect(audioHandler.resetAudioState).toHaveBeenCalled();
+    });
+
+    it('should log an error when the health check request fails', async () => {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network down'))));
+
+        initChatWidget();
+        // fetch の rejection を処理する .catch を待つ
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(errSpy).toHaveBeenCalledWith('[MakaseteAI] Error waiting for data:', expect.any(Error));
+        errSpy.mockRestore();
     });
 
     it('should ignore empty sends', () => {


### PR DESCRIPTION
## 概要

フロントエンドとバックエンドのテストカバレッジを **それぞれ 80% 以上** にしたい、という要望に対応しました。

調査の結果、全体合算のカバレッジは既に 80% を超えていましたが、以下の課題がありました。

- `vitest.config.ts` の閾値が **全体合算のグローバル設定のみ** で、フロント/バックエンドが個別に保証されていなかった（片方が高ければもう片方が低くても合算で通ってしまう）
- **ファイル単位でブランチカバレッジが 80% 未満**のファイルが複数存在した

## 変更内容

### 1. エリア別の閾値強制（`vitest.config.ts`）
`server/**` と `widget/**` のグロブ別閾値（statements/branches/functions/lines すべて 80%）を追加。全体合算だけでなく**各エリア単体でも 80% を割ると CI が落ちる**ようにしました。

### 2. ブランチカバレッジが低かったファイルへのテスト追加
- **`server/services/sheets.ts`**: `getSheetsClient` の認証情報解決分岐（`GOOGLE_APPLICATION_CREDENTIALS` / ローカルキーファイル / 空ファイル / 読込失敗）を網羅
- **`server/services/tts/elevenlabs.ts`**: `voiceId` / `modelId` の既定値フォールバック分岐を網羅
- **`server/services/tts/google.ts`**: GeminiTTS の認証情報解決分岐（env var / ローカルキー / Cloud Run の `K_SERVICE`）を網羅
- **`widget/widget.ts`**: モバイル時のスクロールロック、ランチャーによる閉操作、ヘルスチェック失敗時のエラーログを網羅

## カバレッジ結果（エリア別）

| エリア | Statements | Branches | Functions | Lines |
|--------|-----------|----------|-----------|-------|
| バックエンド (server/) | 95.74% → **99.15%** | 83.90% → **91.53%** | 100% | 96.02% → **99.56%** |
| フロントエンド (widget/) | 97.68% → **98.68%** | 85.52% → **88.28%** | 96.92% → **98.46%** | 98.28% → **99.31%** |

テスト 130 → 140 件、全件パス。`pnpm lint` / `pnpm typecheck` もパス。

## 確認コマンド
```bash
pnpm coverage   # 全テスト + エリア別閾値チェック
pnpm lint
pnpm typecheck
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01FXodtbvL2JhKW9SciWFHwx)_