### PR TITLE
feat: 商品レコメンデーション機能を追加（Sheets主導）

### DIFF
--- a/server/services/chat.ts
+++ b/server/services/chat.ts
@@ -10,6 +10,7 @@ import {
   hasTags,
   removeMarkdownLinks,
 } from "../utils/text";
+import { getRecommendations } from "./recommendations";
 
 export class ChatService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,6 +60,11 @@ export class ChatService {
         role: "model",
         parts: [{ text: fullResponseText }],
       });
+
+      const recommendations = getRecommendations(text, allData);
+      if (recommendations.length > 0) {
+        socket.emit("recommendation", { products: recommendations });
+      }
 
       socket.emit("response-complete");
     } catch (error: unknown) {

--- a/server/services/recommendations.test.ts
+++ b/server/services/recommendations.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { findProductsSheet, getRecommendations } from './recommendations';
+import type { SheetData } from './sheets';
+
+function makeProductSheet(rows: SheetData[]): Map<string, SheetData[]> {
+  return new Map([['products', rows]]);
+}
+
+describe('findProductsSheet', () => {
+  it('should return null when there are no matching sheets', () => {
+    const data = new Map([['faq', [{ question: 'Q', answer: 'A' }]]]);
+    expect(findProductsSheet(data)).toBeNull();
+  });
+
+  it('should find the sheet by exact name "products"', () => {
+    const rows = [{ name: 'Widget', price: '¥1,000' }];
+    const data = new Map([['products', rows]]);
+    expect(findProductsSheet(data)).toBe(rows);
+  });
+
+  it('should find the sheet by exact name "商品"', () => {
+    const rows = [{ name: 'Widget' }];
+    const data = new Map([['商品', rows]]);
+    expect(findProductsSheet(data)).toBe(rows);
+  });
+
+  it('should find a sheet whose name contains "product"', () => {
+    const rows = [{ name: 'Widget' }];
+    const data = new Map([['my_products_list', rows]]);
+    expect(findProductsSheet(data)).toBe(rows);
+  });
+
+  it('should prefer exact name matches over partial matches', () => {
+    const exact = [{ name: 'A' }];
+    const partial = [{ name: 'B' }];
+    const data = new Map<string, SheetData[]>([
+      ['my_products_list', partial],
+      ['products', exact],
+    ]);
+    expect(findProductsSheet(data)).toBe(exact);
+  });
+
+  it('should return null for an empty products sheet', () => {
+    const data = new Map([['products', []]]);
+    expect(findProductsSheet(data)).toBeNull();
+  });
+});
+
+describe('getRecommendations', () => {
+  it('should return empty array when there is no products sheet', () => {
+    expect(getRecommendations('shirt', new Map())).toEqual([]);
+  });
+
+  it('should return empty array when no products match the query', () => {
+    const data = makeProductSheet([
+      { name: 'Laptop', description: 'computer', tags: '' },
+    ]);
+    expect(getRecommendations('shirt', data)).toEqual([]);
+  });
+
+  it('should return matching products sorted by score', () => {
+    const data = makeProductSheet([
+      { name: 'Blue T-Shirt', description: 'cotton shirt', tags: 'shirt,clothing' },
+      { name: 'Laptop Bag', description: 'bag for laptop', tags: 'bag,tech' },
+      { name: 'Red Shirt', description: 'polyester shirt', tags: 'shirt,clothing' },
+    ]);
+    const results = getRecommendations('shirt cotton', data);
+    expect(results[0].name).toBe('Blue T-Shirt');
+    expect(results.map((p) => p.name)).toContain('Red Shirt');
+    expect(results.map((p) => p.name)).not.toContain('Laptop Bag');
+  });
+
+  it('should return at most maxResults products', () => {
+    const rows: SheetData[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `Shirt${i}`,
+      description: 'shirt',
+      tags: 'shirt',
+    }));
+    const data = makeProductSheet(rows);
+    expect(getRecommendations('shirt', data, 3)).toHaveLength(3);
+  });
+
+  it('should skip rows with no name', () => {
+    const data = makeProductSheet([
+      { name: '', description: 'shirt item', tags: 'shirt' },
+      { name: 'Nice Shirt', description: 'cotton shirt', tags: 'shirt' },
+    ]);
+    const results = getRecommendations('shirt', data);
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe('Nice Shirt');
+  });
+
+  it('should handle non-standard column names (product_name, desc, etc.)', () => {
+    const data = makeProductSheet([
+      {
+        product_name: 'Scarf',
+        desc: 'warm scarf',
+        価格: '¥500',
+        image_url: '',
+        url: '',
+        tags: 'scarf',
+      },
+    ]);
+    const results = getRecommendations('scarf', data);
+    expect(results[0].name).toBe('Scarf');
+    expect(results[0].description).toBe('warm scarf');
+    expect(results[0].price).toBe('¥500');
+  });
+
+  it('should match Japanese product names', () => {
+    const data = makeProductSheet([
+      { name: 'シャツ', description: '綿素材のシャツ', tags: '衣類' },
+    ]);
+    const results = getRecommendations('シャツ', data);
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe('シャツ');
+  });
+});

--- a/server/services/recommendations.ts
+++ b/server/services/recommendations.ts
@@ -1,0 +1,74 @@
+import { SheetData } from './sheets';
+
+export interface Product {
+  name: string;
+  description: string;
+  price: string;
+  image_url: string;
+  url: string;
+  tags: string;
+}
+
+const PRODUCT_SHEET_NAMES = ['products', '商品', 'product', 'items'];
+
+export function findProductsSheet(allData: Map<string, SheetData[]>): SheetData[] | null {
+  for (const name of PRODUCT_SHEET_NAMES) {
+    const sheet = allData.get(name);
+    if (sheet && sheet.length > 0) return sheet;
+  }
+  for (const [name, data] of allData.entries()) {
+    if ((name.toLowerCase().includes('product') || name.includes('商品')) && data.length > 0) {
+      return data;
+    }
+  }
+  return null;
+}
+
+function rowToProduct(row: SheetData): Product {
+  return {
+    name: row.name || row.product_name || row['商品名'] || '',
+    description: row.description || row.desc || row['説明'] || '',
+    price: row.price || row['価格'] || row['金額'] || '',
+    image_url: row.image_url || row.image || row['画像'] || row['画像url'] || '',
+    url: row.url || row.link || row['リンク'] || '',
+    tags: row.tags || row.tag || row['タグ'] || '',
+  };
+}
+
+function scoreProduct(query: string, product: Product): number {
+  const queryLower = query.toLowerCase();
+  const tokens = queryLower
+    .split(/[\s,、。！？　]+/)
+    .filter((t) => t.length >= 2);
+
+  if (tokens.length === 0) return 0;
+
+  const productText = [product.name, product.description, product.tags]
+    .join(' ')
+    .toLowerCase();
+
+  return tokens.reduce((score, token) => score + (productText.includes(token) ? 1 : 0), 0);
+}
+
+/**
+ * Returns up to maxResults products from the products sheet that are relevant
+ * to the user's query, ranked by keyword overlap score.
+ */
+export function getRecommendations(
+  userText: string,
+  allData: Map<string, SheetData[]>,
+  maxResults = 3,
+): Product[] {
+  const sheet = findProductsSheet(allData);
+  if (!sheet) return [];
+
+  return sheet
+    .map((row) => {
+      const product = rowToProduct(row);
+      return { product, score: scoreProduct(userText, product) };
+    })
+    .filter(({ product, score }) => score > 0 && product.name.length > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxResults)
+    .map(({ product }) => product);
+}

--- a/server/services/recommendations.ts
+++ b/server/services/recommendations.ts
@@ -37,8 +37,10 @@ function rowToProduct(row: SheetData): Product {
 
 function scoreProduct(query: string, product: Product): number {
   const queryLower = query.toLowerCase();
+  // Split on ASCII whitespace/punctuation first, then split each part on ideographic space (U+3000)
   const tokens = queryLower
-    .split(/[\s,、。！？　]+/)
+    .split(/[\s,、。！？]+/)
+    .flatMap((t) => t.split(String.fromCodePoint(0x3000)))
     .filter((t) => t.length >= 2);
 
   if (tokens.length === 0) return 0;

--- a/widget/styles.css
+++ b/widget/styles.css
@@ -170,6 +170,73 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
+/* Product Recommendations */
+.recommendations {
+  align-self: flex-start;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.product-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background-color: var(--white);
+  border-radius: 10px;
+  padding: 10px;
+  text-decoration: none;
+  color: var(--text-color);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e2e8f0;
+  transition: box-shadow 0.2s, transform 0.2s;
+  cursor: pointer;
+}
+
+.product-card:hover {
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.product-image {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.product-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.product-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.product-desc {
+  font-size: 11px;
+  color: #64748b;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.product-price {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--primary-color);
+  margin-top: 4px;
+}
+
 /* Input Area */
 .input-area {
   padding: 8px 12px 4px;

--- a/widget/types.ts
+++ b/widget/types.ts
@@ -1,0 +1,8 @@
+export interface Product {
+  name: string;
+  description: string;
+  price: string;
+  image_url: string;
+  url: string;
+  tags: string;
+}

--- a/widget/utils/socketHandler.ts
+++ b/widget/utils/socketHandler.ts
@@ -1,4 +1,7 @@
 import { io, Socket } from "socket.io-client";
+import type { Product } from "../types";
+
+export type { Product };
 
 export interface SocketHandlerOptions {
   serverUrl: string;
@@ -7,6 +10,7 @@ export interface SocketHandlerOptions {
   onError: (message: string) => void;
   onConnect?: () => void;
   onResponseComplete?: () => void;
+  onRecommendation?: (products: Product[]) => void;
 }
 
 export interface SocketHandler {
@@ -24,7 +28,7 @@ export interface SocketHandler {
 export function initSocketHandler(
   options: SocketHandlerOptions,
 ): SocketHandler {
-  const { serverUrl, onTextChunk, onAudioChunk, onError, onConnect, onResponseComplete } = options;
+  const { serverUrl, onTextChunk, onAudioChunk, onError, onConnect, onResponseComplete, onRecommendation } = options;
 
   const socket: Socket = io(serverUrl);
 
@@ -49,6 +53,10 @@ export function initSocketHandler(
 
   socket.on("response-complete", () => {
     onResponseComplete?.();
+  });
+
+  socket.on("recommendation", (data: { products: Product[] }) => {
+    onRecommendation?.(data.products);
   });
 
   function sendUserInput(text: string, isVoiceInput: boolean, language = "ja"): void {

--- a/widget/utils/uiRenderer.ts
+++ b/widget/utils/uiRenderer.ts
@@ -1,4 +1,5 @@
 import { formatMessageText } from "./text";
+import type { Product } from "../types";
 
 export interface UIElements {
   container: HTMLElement;
@@ -125,6 +126,60 @@ export function appendMessage(
   div.className = `message ${role}`;
   div.innerHTML = formatMessageText(text);
   timeline.appendChild(div);
+  scrollToBottom(timeline);
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(
+    /[&<>"']/g,
+    (m) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[m] || m,
+  );
+}
+
+/**
+ * 商品レコメンデーションカードをタイムラインに追加する。
+ * 既存のレコメンデーションがある場合は置き換える。
+ */
+export function appendRecommendations(timeline: HTMLElement, products: Product[]): void {
+  const existing = timeline.querySelector(".recommendations");
+  if (existing) existing.remove();
+
+  if (products.length === 0) return;
+
+  const container = document.createElement("div");
+  container.className = "recommendations";
+
+  for (const product of products) {
+    const isValidUrl = /^https?:\/\//.test(product.url);
+    const isValidImageUrl = /^https?:\/\//.test(product.image_url);
+
+    const card = document.createElement(isValidUrl ? "a" : "div");
+    card.className = "product-card";
+    if (isValidUrl && card instanceof HTMLAnchorElement) {
+      card.href = product.url;
+      card.target = "_blank";
+      card.rel = "noopener noreferrer";
+    }
+
+    const imageHtml = isValidImageUrl
+      ? `<img class="product-image" src="${escapeHtml(product.image_url)}" alt="${escapeHtml(product.name)}" loading="lazy">`
+      : "";
+
+    const descHtml = product.description
+      ? `<div class="product-desc">${escapeHtml(product.description)}</div>`
+      : "";
+
+    const priceHtml = product.price
+      ? `<div class="product-price">${escapeHtml(product.price)}</div>`
+      : "";
+
+    card.innerHTML = `${imageHtml}<div class="product-info"><div class="product-name">${escapeHtml(product.name)}</div>${descHtml}${priceHtml}</div>`;
+
+    container.appendChild(card);
+  }
+
+  timeline.appendChild(container);
   scrollToBottom(timeline);
 }
 

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -7,6 +7,7 @@ import {
   updateInputActions,
   showTypingIndicator,
   appendMessage,
+  appendRecommendations,
   hideLoadingOverlay,
   MessageState,
 } from "./utils/uiRenderer";
@@ -154,6 +155,9 @@ export function initChatWidget(config: WidgetConfig = {}): void {
     },
     onResponseComplete: () => {
       els.input.focus();
+    },
+    onRecommendation: (products) => {
+      appendRecommendations(els.timeline, products);
     },
     onConnect: () => {
       console.log("[MakaseteAI] Connected");


### PR DESCRIPTION
closes #223

## Summary
- Google Sheets の `products` シートを商品ソースとしたレコメンデーション機能を追加
- ユーザーの発言とキーワードマッチングし、関連商品をタイムラインにカード表示
- XSS対策済み・既存テストへの影響なし

Generated with [Claude Code](https://claude.ai/code)