### PR TITLE
fix(widget): 音声入力を発話確定後に一度だけ送信する

### DIFF
--- a/widget/utils/audioHandler.test.ts
+++ b/widget/utils/audioHandler.test.ts
@@ -4,6 +4,22 @@ import { initAudioHandler } from './audioHandler';
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
+// SpeechRecognitionEvent を模した結果イベントを組み立てる。
+// results は配列ライク（length/添字アクセス）で、各要素は [{ transcript }] に isFinal を付与したもの。
+function makeResultEvent(
+    resultIndex: number,
+    items: { transcript: string; isFinal: boolean }[],
+) {
+    const results = items.map((it) => {
+        const result: { 0: { transcript: string }; isFinal: boolean } = {
+            0: { transcript: it.transcript },
+            isFinal: it.isFinal,
+        };
+        return result;
+    });
+    return { resultIndex, results: { ...results, length: results.length } };
+}
+
 // --- Web Audio API モック ---
 let createdSources: MockBufferSource[];
 let decodeShouldFail = false;
@@ -195,21 +211,63 @@ describe('initAudioHandler', () => {
             expect(rec.stop).toHaveBeenCalled();
         });
 
-        it('should deliver transcripts and end callbacks', () => {
+        it('should preview interim results without sending, then deliver the final text once on end', () => {
             const { opts } = setup();
             const rec = createdRecognitions[0];
-            rec.onresult!({ results: [[{ transcript: 'hello there' }]] });
-            expect(opts.onTranscript).toHaveBeenCalledWith('hello there');
 
+            // 認識途中（未確定）: 入力欄プレビュー用に onTranscript が呼ばれるだけ
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'こん', isFinal: false }]));
+            expect(opts.onTranscript).toHaveBeenLastCalledWith('こん');
+            // この段階では確定通知（送信トリガー）は来ない
+            expect(opts.onRecordingEnd).not.toHaveBeenCalled();
+
+            // 確定
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'こんにちは', isFinal: true }]));
+            expect(opts.onTranscript).toHaveBeenLastCalledWith('こんにちは');
+
+            // 録音終了で確定テキストを「一度だけ」渡す
             rec.onend!();
-            expect(opts.onRecordingEnd).toHaveBeenCalled();
+            expect(opts.onRecordingEnd).toHaveBeenCalledTimes(1);
+            expect(opts.onRecordingEnd).toHaveBeenCalledWith('こんにちは');
         });
 
-        it('should surface recognition errors', () => {
+        it('should accumulate multiple final segments without duplication', () => {
+            const { opts } = setup();
+            const rec = createdRecognitions[0];
+
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'こんにちは', isFinal: true }]));
+            // event.results は累積。resultIndex 以降（新規分）だけを加算し、確定済みは再加算しない。
+            rec.onresult!(
+                makeResultEvent(1, [
+                    { transcript: 'こんにちは', isFinal: true },
+                    { transcript: 'また明日', isFinal: true },
+                ]),
+            );
+
+            rec.onend!();
+            expect(opts.onRecordingEnd).toHaveBeenCalledWith('こんにちはまた明日');
+        });
+
+        it('should reset accumulated text between recordings', () => {
+            const { handler, opts } = setup();
+            const rec = createdRecognitions[0];
+
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'こんにちは', isFinal: true }]));
+            rec.onend!();
+
+            // 新しい録音を開始すると蓄積はクリアされる
+            handler.toggleRecording();
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'さようなら', isFinal: true }]));
+            rec.onend!();
+
+            expect(opts.onRecordingEnd).toHaveBeenLastCalledWith('さようなら');
+        });
+
+        it('should surface recognition errors and report empty final text', () => {
             const { opts } = setup();
             const rec = createdRecognitions[0];
             rec.onerror!({ error: 'no-speech' });
-            expect(opts.onRecordingEnd).toHaveBeenCalled();
+            expect(opts.onRecordingEnd).toHaveBeenCalledWith('');
             expect(opts.onError).toHaveBeenCalledWith(expect.any(Error));
         });
 

--- a/widget/utils/audioHandler.ts
+++ b/widget/utils/audioHandler.ts
@@ -4,8 +4,10 @@ interface BufferData {
 }
 
 export interface AudioHandlerOptions {
+  /** 認識途中のテキスト（プレビュー用）。送信はしない。 */
   onTranscript: (text: string) => void;
-  onRecordingEnd: () => void;
+  /** 録音終了時に確定したテキストを渡す。空文字なら確定結果なし。 */
+  onRecordingEnd: (finalText: string) => void;
   onError?: (error: Error) => void;
   language?: string;
 }
@@ -45,6 +47,8 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
   // 音声認識
   let recognition: SpeechRecognition | null = null;
   let isRecording = false;
+  // 録音セッション中に確定した（isFinal）テキストを蓄積する
+  let finalTranscript = "";
 
   // --- AudioContext ---
 
@@ -161,21 +165,39 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
     recognition = rec;
     rec.lang = language === "en" ? "en-US" : "ja-JP";
     rec.continuous = false;
-    rec.interimResults = false;
+    // 認識途中の結果も受け取り、入力欄にプレビュー表示する。
+    // ただし送信は発話が確定して録音が終了する onend のタイミングで一度だけ行う。
+    rec.interimResults = true;
 
     rec.onresult = (event: SpeechRecognitionEvent) => {
-      const text = event.results[0][0].transcript;
-      onTranscript(text);
+      // 確定済みテキストは finalTranscript に蓄積し、未確定分のみ interim にまとめる。
+      // event.resultIndex 以降だけを走査することで、確定済み結果の二重加算を防ぐ。
+      let interim = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const transcript = result[0].transcript;
+        if (result.isFinal) {
+          finalTranscript += transcript;
+        } else {
+          interim += transcript;
+        }
+      }
+      // プレビュー表示のみ（この時点では送信しない）
+      onTranscript(finalTranscript + interim);
     };
 
     rec.onend = () => {
       isRecording = false;
-      onRecordingEnd();
+      // 発話が確定したテキストを一度だけ確定通知する
+      const text = finalTranscript.trim();
+      finalTranscript = "";
+      onRecordingEnd(text);
     };
 
     rec.onerror = (event: SpeechRecognitionErrorEvent) => {
       isRecording = false;
-      onRecordingEnd();
+      finalTranscript = "";
+      onRecordingEnd("");
       onError?.(new Error(event.error));
     };
   }
@@ -186,6 +208,7 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
     if (isRecording) {
       recognition.stop();
     } else {
+      finalTranscript = "";
       recognition.start();
       isRecording = true;
     }

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -11,7 +11,7 @@ interface CapturedSocketOpts {
 }
 interface CapturedAudioOpts {
     onTranscript: (text: string) => void;
-    onRecordingEnd: () => void;
+    onRecordingEnd: (finalText: string) => void;
     language?: string;
 }
 
@@ -232,20 +232,33 @@ describe('initChatWidget (rich UI)', () => {
     });
 
     describe('voice', () => {
-        it('onTranscript should populate the input and send as voice', () => {
+        it('onTranscript should preview text in the input without sending', () => {
             initChatWidget();
+            const { input } = getEls();
             captured.audioOpts!.onTranscript('voice text');
+            // 認識途中のテキストは入力欄に表示されるだけで、まだ送信されない
+            expect(input.value).toBe('voice text');
+            expect(socketHandler.sendUserInput).not.toHaveBeenCalled();
+        });
+
+        it('onRecordingEnd should send the finalized text once as voice', () => {
+            initChatWidget();
+            const { micBtn } = getEls();
+            micBtn.classList.add('recording');
+            captured.audioOpts!.onRecordingEnd('voice text');
+            expect(micBtn.classList.contains('recording')).toBe(false);
             expect(socketHandler.sendUserInput).toHaveBeenCalledWith('voice text', true, 'ja');
             expect(audioHandler.resumeAudioContext).toHaveBeenCalled();
             expect(audioHandler.resetAudioState).toHaveBeenCalled();
         });
 
-        it('onRecordingEnd should remove the recording class', () => {
+        it('onRecordingEnd with empty text should not send and just clear recording', () => {
             initChatWidget();
             const { micBtn } = getEls();
             micBtn.classList.add('recording');
-            captured.audioOpts!.onRecordingEnd();
+            captured.audioOpts!.onRecordingEnd('');
             expect(micBtn.classList.contains('recording')).toBe(false);
+            expect(socketHandler.sendUserInput).not.toHaveBeenCalled();
         });
 
         it('mic click should toggle recording when supported', () => {

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -110,11 +110,18 @@ export function initChatWidget(config: WidgetConfig = {}): void {
   // --- Audio ---
   const audio: AudioHandler = initAudioHandler({
     onTranscript: (text) => {
+      // 認識途中のテキストは入力欄にプレビュー表示するだけで送信しない。
+      // （録音中はマイクボタンを出したままにするため updateInputActions は呼ばない）
       els.input.value = text;
-      sendMessage(true);
     },
-    onRecordingEnd: () => {
+    onRecordingEnd: (finalText) => {
       els.micBtn.classList.remove("recording");
+      // 発話が確定したタイミングで、一区切りのテキストとして一度だけ送信する。
+      const text = (finalText ?? "").trim();
+      if (text) {
+        els.input.value = text;
+        sendMessage(true);
+      }
     },
     language,
   });


### PR DESCRIPTION
## 概要

音声入力で発話の途中結果が確定前にチャットへ連投されてしまう問題を修正しました。
「こんにちは」と発話すると `こ` → `こん` → `こんにちは` のように分割送信されていたのを、発話が一区切りついたタイミングで「こんにちは」として一度だけ送信するようにします。

## 原因

`audioHandler` の `onresult`（音声認識の結果イベント）が発火するたびに `onTranscript` 経由で `sendMessage()` を呼んでいたため、認識途中の中間結果まで送信されていました。Web Speech API は環境によって 1 回の発話でも `onresult` を複数回発火するため、その都度メッセージが投稿されていました。

## 変更内容

- **送信トリガーを `onresult` → `onend` に移動**。録音セッションごとに、確定したテキストを一度だけ送信するようにしました。
- **`onresult` は入力欄へのプレビュー表示のみ**を行い、送信はしません。`interimResults` を有効化し、認識途中のテキストを入力欄にライブ表示します。
- `event.resultIndex` 以降のみを走査し、確定済み（`isFinal`）結果の二重加算を防止しました。
- `onRecordingEnd(finalText)` に確定テキストを渡すよう型・呼び出しを変更し、送信判定は `widget.ts` 側で実施します（空文字なら送信しない）。

## テスト

- `widget/utils/audioHandler.test.ts` / `widget/widget.test.ts` を新しい契約に合わせて更新（中間結果はプレビューのみ・確定時に一度だけ送信・確定結果の累積／二重加算防止・録音間のリセットを検証）。
- `pnpm typecheck` / `pnpm lint` / `pnpm test`（159 件）すべてパス。

## 確認手順

1. ウィジェットでマイクボタンを押す
2. 「こんにちは」と発話する
3. 入力欄に認識途中のテキストがプレビュー表示され、発話が確定したタイミングで「こんにちは」が**一度だけ**チャットに送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013kUmBp9agP7vxtEGKExiiW)_