### PR TITLE
fix(widget): settings シートの primary_color / initial_message を表示へ反映

### DIFF
--- a/widget/utils/settings.test.ts
+++ b/widget/utils/settings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { parseSettings } from "./settings";
+
+describe("parseSettings", () => {
+  it("returns an empty object for empty or invalid input", () => {
+    expect(parseSettings([])).toEqual({});
+    expect(parseSettings(null)).toEqual({});
+    expect(parseSettings(undefined)).toEqual({});
+    expect(parseSettings("nope")).toEqual({});
+    expect(parseSettings([null])).toEqual({});
+  });
+
+  it("parses the key-value format", () => {
+    const result = parseSettings([
+      { key: "primary_color", value: "#FF0000" },
+      { key: "initial_message", value: "こんにちは" },
+      { key: "chat_title", value: "マイAI" },
+    ]);
+    expect(result).toEqual({
+      primaryColor: "#FF0000",
+      initialMessage: "こんにちは",
+      title: "マイAI",
+    });
+  });
+
+  it("parses the single-row column format", () => {
+    const result = parseSettings([
+      { primary_color: "#00FF00", initial_message: "hi", chat_title: "Bot" },
+    ]);
+    expect(result).toEqual({
+      primaryColor: "#00FF00",
+      initialMessage: "hi",
+      title: "Bot",
+    });
+  });
+
+  it("normalizes key variations and trims values", () => {
+    const result = parseSettings([
+      { key: "Primary Color", value: "  #abc  " },
+      { key: "Greeting", value: "やあ" },
+      { key: "Title", value: "T" },
+    ]);
+    expect(result).toEqual({
+      primaryColor: "#abc",
+      initialMessage: "やあ",
+      title: "T",
+    });
+  });
+
+  it("supports the short aliases color / greeting / title", () => {
+    const result = parseSettings([
+      { key: "color", value: "#111" },
+      { key: "greeting", value: "よろしく" },
+    ]);
+    expect(result).toEqual({ primaryColor: "#111", initialMessage: "よろしく" });
+  });
+
+  it("ignores unrelated keys and empty values", () => {
+    const result = parseSettings([
+      { key: "unknown", value: "x" },
+      { key: "primary_color", value: "" },
+    ]);
+    expect(result).toEqual({});
+  });
+
+  it("skips non-record / keyless / null-value rows in key-value data", () => {
+    const result = parseSettings([
+      { key: "primary_color", value: "#111" },
+      null,
+      "junk",
+      { key: "", value: "ignored" },
+      { key: "initial_message", value: null },
+    ]);
+    expect(result).toEqual({ primaryColor: "#111" });
+  });
+
+  it("treats null values as empty in the single-row column format", () => {
+    const result = parseSettings([
+      { primary_color: "#222", initial_message: null },
+    ]);
+    expect(result).toEqual({ primaryColor: "#222" });
+  });
+});

--- a/widget/utils/settings.ts
+++ b/widget/utils/settings.ts
@@ -1,0 +1,66 @@
+/**
+ * settings シート由来の生データから、ウィジェット表示に反映する設定を抽出する。
+ */
+import { normalizeSettingKey } from "./text";
+
+export interface WidgetSettings {
+  /** チャットヘッダーのタイトル */
+  title?: string;
+  /** 初回に表示する挨拶メッセージ */
+  initialMessage?: string;
+  /** プライマリカラー（Shadow Host の --primary-color に適用） */
+  primaryColor?: string;
+}
+
+type SettingsRow = Record<string, string>;
+
+function isRecord(value: unknown): value is SettingsRow {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * `/api/settings` のレスポンス（settings シートの内容）から設定を取り出す。
+ *
+ * 以下の2形式に対応する:
+ *  - key-value 形式: `[{ key: "primary_color", value: "#FF0000" }, ...]`
+ *  - 列形式（単一行）: `[{ primary_color: "#FF0000", initial_message: "...", ... }]`
+ *
+ * キーは {@link normalizeSettingKey} で正規化して照合するため、
+ * `Primary Color` / `primary_color` / `primaryColor` などの表記揺れを吸収する。
+ * 該当する設定が無い（または空文字）の場合は undefined を返し、呼び出し側の
+ * デフォルト値にフォールバックできるようにする。
+ */
+export function parseSettings(data: unknown): WidgetSettings {
+  if (!Array.isArray(data) || data.length === 0) return {};
+
+  const first = data[0];
+  if (!isRecord(first)) return {};
+
+  const map = new Map<string, string>();
+  const isKeyValue = "key" in first && "value" in first;
+
+  if (isKeyValue) {
+    for (const row of data) {
+      if (!isRecord(row) || !row.key) continue;
+      map.set(normalizeSettingKey(String(row.key)), String(row.value ?? "").trim());
+    }
+  } else {
+    for (const [key, value] of Object.entries(first)) {
+      map.set(normalizeSettingKey(key), String(value ?? "").trim());
+    }
+  }
+
+  const pick = (...keys: string[]): string | undefined => {
+    for (const key of keys) {
+      const value = map.get(key);
+      if (value) return value;
+    }
+    return undefined;
+  };
+
+  return {
+    title: pick("chattitle", "title"),
+    initialMessage: pick("initialmessage", "greeting"),
+    primaryColor: pick("primarycolor", "color"),
+  };
+}

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -77,9 +77,18 @@ describe('initChatWidget (rich UI)', () => {
         audioHandler.isSpeechRecognitionSupported.mockReturnValue(true);
         audioHandler.resumeAudioContext.mockReturnValue(Promise.resolve());
         window.alert = vi.fn();
-        // fetch(/health) はローディング解除に使われる
-        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)));
+        // fetch(/health) はローディング解除、fetch(/api/settings) は設定取得に使われる。
+        // デフォルトでは設定なし（空配列）を返し、config 由来のデフォルトが使われるようにする。
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(() =>
+                Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as unknown as Response),
+            ),
+        );
     });
+
+    // fetch チェーン（health -> settings -> json）の解決を待つためのヘルパー
+    const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
 
     afterEach(() => {
         // stubGlobal(innerWidth / fetch) のテスト間汚染を防ぐ
@@ -102,8 +111,9 @@ describe('initChatWidget (rich UI)', () => {
         expect(input.placeholder).toBe('質問を入力...');
     });
 
-    it('should render the initial greeting message', () => {
+    it('should render the initial greeting message after settings load', async () => {
         initChatWidget();
+        await flushAsync();
         const { timeline } = getEls();
         const greeting = timeline.querySelector('.message.makasete-server');
         expect(greeting?.innerHTML).toContain('AIアシスタント');
@@ -155,6 +165,114 @@ describe('initChatWidget (rich UI)', () => {
 
         expect(errSpy).toHaveBeenCalledWith('[MakaseteAI] Error waiting for data:', expect.any(Error));
         errSpy.mockRestore();
+    });
+
+    describe('settings sheet reflection', () => {
+        const stubFetchWithSettings = (settings: unknown) => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn((url: string) => {
+                    if (typeof url === 'string' && url.endsWith('/api/settings')) {
+                        return Promise.resolve({
+                            ok: true,
+                            json: () => Promise.resolve(settings),
+                        } as unknown as Response);
+                    }
+                    return Promise.resolve({
+                        ok: true,
+                        json: () => Promise.resolve([]),
+                    } as unknown as Response);
+                }),
+            );
+        };
+
+        it('applies primary_color, initial_message and chat_title (key-value format)', async () => {
+            stubFetchWithSettings([
+                { key: 'primary_color', value: '#ff8800' },
+                { key: 'initial_message', value: 'カスタム挨拶です' },
+                { key: 'chat_title', value: 'サポートAI' },
+            ]);
+            initChatWidget();
+            await flushAsync();
+
+            const { shadow, chatTitle, timeline } = getEls();
+            expect((shadow.host as HTMLElement).style.getPropertyValue('--primary-color')).toBe('#ff8800');
+            expect(chatTitle.textContent).toBe('サポートAI');
+            expect(timeline.querySelector('.message.makasete-server')?.innerHTML).toContain('カスタム挨拶です');
+        });
+
+        it('applies settings provided in the single-row column format', async () => {
+            stubFetchWithSettings([
+                { primary_color: '#123456', initial_message: 'row形式の挨拶', chat_title: 'Row Bot' },
+            ]);
+            initChatWidget();
+            await flushAsync();
+
+            const { shadow, chatTitle, timeline } = getEls();
+            expect((shadow.host as HTMLElement).style.getPropertyValue('--primary-color')).toBe('#123456');
+            expect(chatTitle.textContent).toBe('Row Bot');
+            expect(timeline.querySelector('.message.makasete-server')?.innerHTML).toContain('row形式の挨拶');
+        });
+
+        it('keeps the config defaults when the settings sheet is empty', async () => {
+            stubFetchWithSettings([]);
+            initChatWidget();
+            await flushAsync();
+
+            const { shadow, chatTitle, timeline } = getEls();
+            expect(chatTitle.textContent).toBe('AIアシスタント');
+            expect(timeline.querySelector('.message.makasete-server')?.innerHTML).toContain('AIアシスタント');
+            // 設定が無い場合は --primary-color を上書きせず CSS のデフォルトを使う
+            expect((shadow.host as HTMLElement).style.getPropertyValue('--primary-color')).toBe('');
+        });
+
+        it('keeps the config defaults when the settings endpoint returns 404', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn((url: string) => {
+                    if (typeof url === 'string' && url.endsWith('/api/settings')) {
+                        return Promise.resolve({
+                            ok: false,
+                            json: () => Promise.resolve({ error: 'not found' }),
+                        } as unknown as Response);
+                    }
+                    return Promise.resolve({
+                        ok: true,
+                        json: () => Promise.resolve([]),
+                    } as unknown as Response);
+                }),
+            );
+            initChatWidget();
+            await flushAsync();
+
+            const { chatTitle, timeline } = getEls();
+            expect(chatTitle.textContent).toBe('AIアシスタント');
+            expect(timeline.querySelector('.message.makasete-server')?.innerHTML).toContain('AIアシスタント');
+        });
+
+        it('warns when the health check returns a non-ok status', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            vi.stubGlobal(
+                'fetch',
+                vi.fn((url: string) => {
+                    if (typeof url === 'string' && url.endsWith('/health')) {
+                        return Promise.resolve({
+                            ok: false,
+                            json: () => Promise.resolve([]),
+                        } as unknown as Response);
+                    }
+                    return Promise.resolve({
+                        ok: true,
+                        json: () => Promise.resolve([]),
+                    } as unknown as Response);
+                }),
+            );
+            initChatWidget();
+            await flushAsync();
+
+            expect(warnSpy).toHaveBeenCalledWith('[MakaseteAI] Failed to verify data readiness');
+            warnSpy.mockRestore();
+        });
     });
 
     it('should ignore empty sends', () => {

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -8,9 +8,11 @@ import {
   showTypingIndicator,
   appendMessage,
   appendRecommendations,
+  applyPrimaryColor,
   hideLoadingOverlay,
   MessageState,
 } from "./utils/uiRenderer";
+import { parseSettings } from "./utils/settings";
 
 interface WidgetConfig {
   serverUrl?: string;
@@ -252,17 +254,35 @@ export function initChatWidget(config: WidgetConfig = {}): void {
     isDragging = dragging;
   });
 
-  // --- データ準備の完了を待ってローディングを解除 ---
-  fetch(`${serverUrl}/health`)
-    .then((response) => {
-      if (response.ok) {
-        hideLoadingOverlay(els.loadingOverlay);
-      }
-    })
-    .catch((e) => {
-      console.error("[MakaseteAI] Error waiting for data:", e);
-    });
+  // --- データ準備の完了を待ち、settings シートの設定を反映してローディングを解除 ---
+  // Google Sheets の settings シート（primary_color / initial_message / chat_title）を
+  // 取得して表示に反映する。Sheets が唯一の真実であり、取得に失敗した場合や設定が
+  // 無い場合のみ config 由来のデフォルトへフォールバックする。
+  async function initializeWidget(): Promise<void> {
+    let greetingToRender = greeting;
 
-  // 初回の挨拶メッセージ
-  appendMessage(els.timeline, messageState, "makasete-server", greeting);
+    try {
+      // /health はサーバー側でデータ取得完了までブロックする
+      const healthResponse = await fetch(`${serverUrl}/health`);
+      if (!healthResponse.ok) {
+        console.warn("[MakaseteAI] Failed to verify data readiness");
+      }
+
+      const settingsResponse = await fetch(`${serverUrl}/api/settings`);
+      if (settingsResponse.ok) {
+        const settings = parseSettings(await settingsResponse.json());
+        if (settings.title) els.chatTitle.textContent = settings.title;
+        if (settings.primaryColor) applyPrimaryColor(shadow, settings.primaryColor);
+        if (settings.initialMessage) greetingToRender = settings.initialMessage;
+      }
+    } catch (e) {
+      console.error("[MakaseteAI] Error waiting for data:", e);
+    } finally {
+      // 初回の挨拶メッセージ（settings 反映後に一度だけ表示する）
+      appendMessage(els.timeline, messageState, "makasete-server", greetingToRender);
+      hideLoadingOverlay(els.loadingOverlay);
+    }
+  }
+
+  void initializeWidget();
 }


### PR DESCRIPTION
## 概要

スプレッドシートの `settings` シートで設定した `primary_color` や `initial_message` がウィジェットの表示に反映されない不具合を修正します。

## 原因

`ChatWidget` クラスから関数型の `initChatWidget` へリファクタリングした際（#85）に、`/api/settings` を取得して設定を反映する処理が**まるごと欠落**していました。その結果、現在のウィジェットは `/health` のみを取得し、挨拶メッセージ・タイトル・プライマリカラーはすべてハードコード値のままになっていました。

なお、下記の2つのヘルパーは残っていたものの、どこからも呼ばれない「孤立した」状態でした（テストのみ存在）:

- `normalizeSettingKey`（`widget/utils/text.ts`）
- `applyPrimaryColor`（`widget/utils/uiRenderer.ts`）

## 変更内容

- ウィジェット初期化時に `/api/settings` を取得し、設定を表示へ反映するように復元しました。
  - `primary_color` → Shadow Host の `--primary-color` に適用（`applyPrimaryColor` を利用）
  - `initial_message` → 初回の挨拶メッセージとして表示
  - `chat_title` → チャットヘッダーのタイトルに反映
- 設定の抽出ロジックを `widget/utils/settings.ts`（`parseSettings`）へ切り出しました。孤立していた `normalizeSettingKey` を再利用し、以下の2形式に対応します。
  - key-value 形式: `[{ key: "primary_color", value: "#FF0000" }, ...]`
  - 単一行の列形式: `[{ primary_color: "#FF0000", initial_message: "...", ... }]`
  - `Primary Color` / `primary_color` / `primaryColor` などの表記揺れも正規化して吸収します。
- 取得失敗時・設定が無い場合は、これまで通り `config` 由来のデフォルトへフォールバックします（Sheets を唯一の真実とし、無い場合のみデフォルト）。

## テスト

- `widget/utils/settings.test.ts`: `parseSettings` のユニットテスト（両形式・エイリアス・正規化・空値・不正入力のガード）を追加。
- `widget/widget.test.ts`: `/api/settings` 経由で `primary_color` / `initial_message` / `chat_title` が反映されること、空シート・404・health 非ok時のフォールバックを追加。

### 実行結果

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test`（179 tests）✅
- `pnpm coverage` ✅（`widget/**`・`server/**` ともに 80% 閾値を満たす）
- `pnpm build:widget` ✅（生成物に `/api/settings` 反映ロジックを含むことを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c6tJVGRXc2KTivCxRcgnX

---
_Generated by [Claude Code](https://claude.ai/code/session_011c6tJVGRXc2KTivCxRcgnX)_