### PR TITLE
Gemini LLM と TTS のモデルを最新化 (gemini-3.5-flash / Chirp 3: HD)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This document defines the shared rules and standards for all AI agents interacti
 
 -   **Runtime**: Node.js v24 (LTS)
 -   **Package Manager**: `pnpm` (v10+) - `npm` や `yarn` は使用禁止。
--   **Main LLM**: Google Gemini API (`gemini-2.5-flash`)
+-   **Main LLM**: Google Gemini API (`gemini-3.5-flash`)
 -   **Autonomous Agent**: LangGraph + Claude 4.6 Sonnet
 -   **Frontend**: Vanilla TypeScript + Vite (No Heavy Frameworks like React/Vue in the widget itself)
 -   **Backend**: Express + Socket.io + LangChain/LangGraph

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ECサイトやサービスサイトに簡単導入でき、音声とテキスト
 
 - **技術スタック**: Node.js (v24), Express, Socket.io, **LangChain (LangGraph)**
 - **AI処理**:
-  - **LLM**: Google Gemini API (gemini-2.5-flash)
+  - **LLM**: Google Gemini API (gemini-3.5-flash)
   - **オーケストレーション**: LangChain / LangGraph によるエージェント構成
   - **TTS**: Google Cloud Text-to-Speech (デフォルト) または ElevenLabs API
 - **データ連携**: Google Sheets API (商品情報・FAQ・サービス紹介・システムプロンプトの取得)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ECサイトやサービスサイトに簡単導入でき、音声とテキスト
 - **AI処理**:
   - **LLM**: Google Gemini API (gemini-3.5-flash)
   - **オーケストレーション**: LangChain / LangGraph によるエージェント構成
-  - **TTS**: Google Cloud Text-to-Speech (デフォルト) または ElevenLabs API
+  - **TTS**: Google Cloud Text-to-Speech (デフォルト, Chirp 3: HD ボイス) または ElevenLabs API
 - **データ連携**: Google Sheets API (商品情報・FAQ・サービス紹介・システムプロンプトの取得)
 
 ## 自律型開発エージェント (Autonomous Agent)

--- a/server/services/gemini.test.ts
+++ b/server/services/gemini.test.ts
@@ -105,7 +105,7 @@ describe('Gemini service utilities', () => {
             initGemini();
 
             expect(GoogleGenerativeAI).toHaveBeenCalledWith('test-key');
-            expect(getGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-2.5-flash' });
+            expect(getGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-3.5-flash' });
             config.geminiApiKey = original;
         });
     });

--- a/server/services/gemini.ts
+++ b/server/services/gemini.ts
@@ -12,8 +12,8 @@ export function initGemini() {
         return;
     }
     genAI = new GoogleGenerativeAI(config.geminiApiKey);
-    // Use gemini-2.5-flash as originally intended, non-JSON streaming mode
-    model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+    // Use the latest Flash model, non-JSON streaming mode
+    model = genAI.getGenerativeModel({ model: "gemini-3.5-flash" });
 }
 
 /**

--- a/server/services/tts/google.test.ts
+++ b/server/services/tts/google.test.ts
@@ -87,7 +87,7 @@ describe('GeminiTTSService', () => {
 
         const reqBody = synthesize.mock.calls[0][0].requestBody;
         expect(reqBody.input).toEqual({ text: 'こんにちは' });
-        expect(reqBody.voice).toEqual({ languageCode: 'ja-JP', name: 'ja-JP-Neural2-D' });
+        expect(reqBody.voice).toEqual({ languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Charon' });
 
         const chunks: Buffer[] = [];
         for await (const c of stream) chunks.push(c as Buffer);
@@ -103,7 +103,7 @@ describe('GeminiTTSService', () => {
 
         const reqBody = synthesize.mock.calls[0][0].requestBody;
         expect(reqBody.input).toEqual({ ssml: '<speak>hi</speak>' });
-        expect(reqBody.voice).toEqual({ languageCode: 'en-US', name: 'en-US-Neural2-D' });
+        expect(reqBody.voice).toEqual({ languageCode: 'en-US', name: 'en-US-Chirp3-HD-Charon' });
     });
 
     it('should fall back to the Japanese voice for unknown languages', async () => {

--- a/server/services/tts/google.test.ts
+++ b/server/services/tts/google.test.ts
@@ -87,7 +87,7 @@ describe('GeminiTTSService', () => {
 
         const reqBody = synthesize.mock.calls[0][0].requestBody;
         expect(reqBody.input).toEqual({ text: 'こんにちは' });
-        expect(reqBody.voice).toEqual({ languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Charon' });
+        expect(reqBody.voice).toEqual({ languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Kore' });
 
         const chunks: Buffer[] = [];
         for await (const c of stream) chunks.push(c as Buffer);
@@ -103,7 +103,7 @@ describe('GeminiTTSService', () => {
 
         const reqBody = synthesize.mock.calls[0][0].requestBody;
         expect(reqBody.input).toEqual({ ssml: '<speak>hi</speak>' });
-        expect(reqBody.voice).toEqual({ languageCode: 'en-US', name: 'en-US-Chirp3-HD-Charon' });
+        expect(reqBody.voice).toEqual({ languageCode: 'en-US', name: 'en-US-Chirp3-HD-Kore' });
     });
 
     it('should fall back to the Japanese voice for unknown languages', async () => {

--- a/server/services/tts/google.ts
+++ b/server/services/tts/google.ts
@@ -36,9 +36,12 @@ export class GeminiTTSService implements TTSService {
         return this.client;
     }
 
+    // Chirp 3: HD voices — the latest high-fidelity generation, suitable for
+    // low-latency real-time synthesis. Voice names are shared across locales
+    // in the <locale>-Chirp3-HD-<voice> format.
     private static readonly VOICES: Record<string, texttospeech_v1.Schema$VoiceSelectionParams> = {
-        ja: { languageCode: 'ja-JP', name: 'ja-JP-Neural2-D' },
-        en: { languageCode: 'en-US', name: 'en-US-Neural2-D' },
+        ja: { languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Charon' },
+        en: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Charon' },
     };
 
     public async generateSpeechStream(text: string, language = 'ja'): Promise<Readable> {
@@ -52,9 +55,10 @@ export class GeminiTTSService implements TTSService {
                     requestBody: {
                         input: isSsml ? { ssml: text } : { text },
                         voice,
+                        // Note: Chirp 3 HD voices do not support the speakingRate
+                        // (or pitch) parameter, so it is intentionally omitted.
                         audioConfig: {
                             audioEncoding: 'MP3',
-                            speakingRate: 1.15,
                         },
                     }
                 }, (err, res) => {

--- a/server/services/tts/google.ts
+++ b/server/services/tts/google.ts
@@ -38,10 +38,11 @@ export class GeminiTTSService implements TTSService {
 
     // Chirp 3: HD voices — the latest high-fidelity generation, suitable for
     // low-latency real-time synthesis. Voice names are shared across locales
-    // in the <locale>-Chirp3-HD-<voice> format.
+    // in the <locale>-Chirp3-HD-<voice> format. "Kore" is a calm, composed
+    // voice that fits customer-support / help-desk / FAQ use cases.
     private static readonly VOICES: Record<string, texttospeech_v1.Schema$VoiceSelectionParams> = {
-        ja: { languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Charon' },
-        en: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Charon' },
+        ja: { languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Kore' },
+        en: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Kore' },
     };
 
     public async generateSpeechStream(text: string, language = 'ja'): Promise<Readable> {


### PR DESCRIPTION
## 概要

メイン LLM と TTS のモデルを最新世代に更新しました。

### 1. メイン LLM: `gemini-2.5-flash` → `gemini-3.5-flash`

`gemini-3.5-flash` は現行 GA の最新 Flash モデル（`gemini-flash-latest` エイリアスの実体）。将来の自動切り替えによる挙動変化を避けるため、エイリアスではなく具体的なバージョン ID にピン留めしています。

### 2. デフォルト TTS: Google Cloud TTS を Neural2 → Chirp 3: HD ボイスに更新

- `ja-JP-Neural2-D` / `en-US-Neural2-D`（旧世代）→ **`ja-JP-Chirp3-HD-Kore` / `en-US-Chirp3-HD-Kore`**（最新の高品質 HD ボイス、リアルタイム/低遅延用途向け）。
- **ボイス選定**: `Kore` は落ち着いた芯のある声で、EC 接客・ヘルプデスク・FAQ チャットなど日本語の顧客対応用途に適合。英語併用時も声質を統一するため en-US も同じ `Kore` を使用。
- **注意**: Chirp 3 HD ボイスは `speakingRate` / `pitch` パラメータをサポートしないため、従来の `speakingRate: 1.15` 指定を削除しました。読み上げ速度は既定値になります。
- ElevenLabs（代替プロバイダー）は `eleven_flash_v2_5` のまま据え置き。これは現時点でも最新の低遅延 Flash モデルであり、AGENTS.md の Zero-Latency 最優先方針に最も適合するためです（v3 は表現力重視だが高遅延）。

## 変更ファイル

- `server/services/gemini.ts` / `server/services/gemini.test.ts`: LLM モデル指定
- `server/services/tts/google.ts` / `server/services/tts/google.test.ts`: TTS ボイス世代と audioConfig
- `AGENTS.md` / `README.md`: ドキュメント表記

## テスト

- `pnpm vitest run server/services/gemini.test.ts` → 12 passed
- `pnpm vitest run server/services/tts/google.test.ts` → 10 passed
- `pnpm typecheck` → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)