### PR TITLE
fix(voice): 発話中のマイク押下でボット音声を止める / 音声チャットの改善

### DIFF
--- a/server/services/chat.test.ts
+++ b/server/services/chat.test.ts
@@ -206,6 +206,86 @@ describe('ChatService', () => {
         });
     });
 
+    describe('cancellation (barge-in)', () => {
+        const tick = () => new Promise((r) => setTimeout(r, 0));
+
+        it('supersedes an in-flight response when a newer input arrives', async () => {
+            const socket = makeSocket();
+            const svc = new ChatService();
+
+            let releaseFirst!: () => void;
+            const firstGate = new Promise<void>((r) => {
+                releaseFirst = r;
+            });
+
+            generateResponseStream.mockReset();
+            generateResponseStream
+                .mockImplementationOnce(async () =>
+                    (async function* () {
+                        yield { text: () => '最初の文。' };
+                        await firstGate; // 2つ目の入力が割り込むまで停止
+                        yield { text: () => '割り込み後の文。' };
+                    })(),
+                )
+                .mockImplementationOnce(async () => makeStream(['新しい応答。']));
+
+            const p1 = svc.handleUserInput(socket as never, { text: 'first', isVoiceInput: false });
+            await tick(); // 1つ目が最初の文を処理して停止するまで待つ
+            const p2 = svc.handleUserInput(socket as never, { text: 'second', isVoiceInput: false });
+            releaseFirst();
+            await Promise.all([p1, p2]);
+
+            // 割り込まれた1つ目は完了イベントを出さず、2つ目のみ完了する
+            const completes = socket.emit.mock.calls.filter((c) => c[0] === 'response-complete');
+            expect(completes).toHaveLength(1);
+            // 割り込み後のチャンクは送信されない
+            const staleChunk = socket.emit.mock.calls.find(
+                (c) => c[0] === 'text-chunk' && c[1].content === '割り込み後の文。',
+            );
+            expect(staleChunk).toBeUndefined();
+            // 新しい応答は送信される
+            expect(socket.emit).toHaveBeenCalledWith('text-chunk', { content: '新しい応答。' });
+        });
+
+        it('drops the superseded response from chat history', async () => {
+            const socket = makeSocket();
+            const svc = new ChatService();
+
+            let releaseFirst!: () => void;
+            const firstGate = new Promise<void>((r) => {
+                releaseFirst = r;
+            });
+
+            generateResponseStream.mockReset();
+            generateResponseStream
+                .mockImplementationOnce(async () =>
+                    (async function* () {
+                        yield { text: () => '古い応答。' };
+                        await firstGate;
+                    })(),
+                )
+                .mockImplementationOnce(async () => makeStream(['新しい応答。']))
+                .mockImplementationOnce(async () => makeStream(['3回目。']));
+
+            const p1 = svc.handleUserInput(socket as never, { text: 'first', isVoiceInput: false });
+            await tick();
+            const p2 = svc.handleUserInput(socket as never, { text: 'second', isVoiceInput: false });
+            releaseFirst();
+            await Promise.all([p1, p2]);
+
+            // 3回目の入力に渡る履歴を検査する
+            await svc.handleUserInput(socket as never, { text: 'third', isVoiceInput: false });
+            const history = generateResponseStream.mock.calls.at(-1)![2] as {
+                role: string;
+                parts: { text: string }[];
+            }[];
+            const modelTexts = history.filter((h) => h.role === 'model').map((h) => h.parts[0].text);
+            // 割り込まれた「古い応答。」はモデル履歴に残らない
+            expect(modelTexts).toContain('新しい応答。');
+            expect(modelTexts).not.toContain('古い応答。');
+        });
+    });
+
     describe('error handling', () => {
         it('should emit an internal error when the generator throws', async () => {
             generateResponseStream.mockRejectedValue(new Error('gemini down'));

--- a/server/services/chat.test.ts
+++ b/server/services/chat.test.ts
@@ -247,6 +247,82 @@ describe('ChatService', () => {
             expect(socket.emit).toHaveBeenCalledWith('text-chunk', { content: '新しい応答。' });
         });
 
+        it('does not emit stale text or audio for a superseded voice response', async () => {
+            const socket = makeSocket();
+            const svc = new ChatService();
+
+            let releaseFirst!: () => void;
+            const firstGate = new Promise<void>((r) => {
+                releaseFirst = r;
+            });
+
+            generateResponseStream.mockReset();
+            generateResponseStream
+                .mockImplementationOnce(async () =>
+                    (async function* () {
+                        yield { text: () => '最初の音声。' };
+                        await firstGate; // 2つ目の入力が割り込むまで停止
+                        yield { text: () => '割り込み後の音声。' };
+                    })(),
+                )
+                .mockImplementationOnce(async () => makeStream(['新しい音声。']));
+
+            const p1 = svc.handleUserInput(socket as never, { text: 'first', isVoiceInput: true });
+            await tick();
+            const p2 = svc.handleUserInput(socket as never, { text: 'second', isVoiceInput: true });
+            releaseFirst();
+            await Promise.all([p1, p2]);
+
+            // 割り込み後の文はテキスト（audio-chunk type:text）として送信されない
+            const staleText = socket.emit.mock.calls.find(
+                (c) =>
+                    c[0] === 'audio-chunk' &&
+                    c[1].type === 'text' &&
+                    c[1].content === '割り込み後の音声。',
+            );
+            expect(staleText).toBeUndefined();
+            // 完了は新しい応答の1回のみ
+            const completes = socket.emit.mock.calls.filter((c) => c[0] === 'response-complete');
+            expect(completes).toHaveLength(1);
+            // 新しい応答は送信される
+            expect(socket.emit).toHaveBeenCalledWith('audio-chunk', { type: 'text', content: '新しい音声。' });
+        });
+
+        it('does not emit an error for a response that was already superseded', async () => {
+            const socket = makeSocket();
+            const svc = new ChatService();
+
+            let releaseFirst!: () => void;
+            const firstGate = new Promise<void>((r) => {
+                releaseFirst = r;
+            });
+
+            generateResponseStream.mockReset();
+            generateResponseStream
+                .mockImplementationOnce(async () =>
+                    (async function* () {
+                        yield { text: () => '途中。' };
+                        await firstGate;
+                        throw new Error('late failure'); // 割り込み後に失敗する
+                    })(),
+                )
+                .mockImplementationOnce(async () => makeStream(['新しい応答。']));
+
+            const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const p1 = svc.handleUserInput(socket as never, { text: 'first', isVoiceInput: false });
+            await tick();
+            const p2 = svc.handleUserInput(socket as never, { text: 'second', isVoiceInput: false });
+            releaseFirst();
+            await Promise.all([p1, p2]);
+            errSpy.mockRestore();
+
+            // 割り込まれた応答が失敗しても、ユーザーにはエラーを通知しない
+            const errors = socket.emit.mock.calls.filter((c) => c[0] === 'error');
+            expect(errors).toHaveLength(0);
+            // 新しい応答は正常に完了する
+            expect(socket.emit).toHaveBeenCalledWith('response-complete');
+        });
+
         it('drops the superseded response from chat history', async () => {
             const socket = makeSocket();
             const svc = new ChatService();

--- a/server/services/chat.ts
+++ b/server/services/chat.ts
@@ -18,6 +18,10 @@ const MIN_AUDIO_CHUNK_BYTES = 4 * 1024;
 export class ChatService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private chatHistory: any[] = [];
+  // Monotonically increasing id of the latest input. A newer input supersedes
+  // (cancels) any response still being generated on the same socket, so a user
+  // interrupting the bot (barge-in) does not produce overlapping responses.
+  private activeGeneration = 0;
 
   async handleUserInput(
     socket: Socket,
@@ -29,6 +33,11 @@ export class ChatService {
       socket.emit("error", { message: "Input is invalid" });
       return;
     }
+
+    // Claim this generation; if a newer input arrives it will bump the counter
+    // and every guarded step below stops emitting for this (now stale) response.
+    const generation = ++this.activeGeneration;
+    const isSuperseded = (): boolean => generation !== this.activeGeneration;
 
     this.chatHistory.push({ role: "user", parts: [{ text }] });
     if (this.chatHistory.length > 20) {
@@ -49,6 +58,7 @@ export class ChatService {
       let audioEmitChain: Promise<void> = Promise.resolve();
 
       const enqueueSentence = (sentence: string): void => {
+        if (isSuperseded()) return;
         const uiText = stripTags(sentence);
 
         if (isVoiceInput) {
@@ -58,15 +68,23 @@ export class ChatService {
           const streamPromise = this.startEagerTTSStream(sentence, ttsService, language);
 
           // Chain: emit this sentence's audio only after the previous one finishes
-          audioEmitChain = audioEmitChain.then(() =>
-            this.drainStreamToSocket(socket, streamPromise),
-          );
+          audioEmitChain = audioEmitChain.then(() => {
+            if (isSuperseded()) {
+              // Superseded by a newer input: discard the buffered audio without
+              // emitting it. Resuming with no data listener drains and drops it.
+              return streamPromise.then((s) => {
+                s?.resume();
+              });
+            }
+            return this.drainStreamToSocket(socket, streamPromise);
+          });
         } else {
           socket.emit("text-chunk", { content: uiText });
         }
       };
 
       for await (const chunk of stream) {
+        if (isSuperseded()) break;
         const chunkText = chunk.text();
         fullResponseText += chunkText;
 
@@ -76,13 +94,20 @@ export class ChatService {
         }
       }
 
-      const remaining = streamBuffer.flush();
-      if (remaining) {
-        enqueueSentence(remaining);
+      if (!isSuperseded()) {
+        const remaining = streamBuffer.flush();
+        if (remaining) {
+          enqueueSentence(remaining);
+        }
       }
 
       // Wait for all audio to finish before signaling completion
       await audioEmitChain;
+
+      // A newer input arrived while generating: drop this stale response entirely
+      // (no history push, recommendations or completion) to keep the conversation
+      // order intact and avoid emitting events that overlap the newer response.
+      if (isSuperseded()) return;
 
       this.chatHistory.push({
         role: "model",
@@ -98,7 +123,10 @@ export class ChatService {
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       console.error("Error processing input:", message);
-      socket.emit("error", { message: "Internal server error occurred." });
+      // Only surface the error for the response the client is still expecting.
+      if (!isSuperseded()) {
+        socket.emit("error", { message: "Internal server error occurred." });
+      }
     }
   }
 

--- a/widget/utils/audioHandler.test.ts
+++ b/widget/utils/audioHandler.test.ts
@@ -254,6 +254,29 @@ describe('initAudioHandler', () => {
             expect(rec.stop).toHaveBeenCalled();
         });
 
+        it('should return the resulting recording state on toggle', () => {
+            const { handler } = setup();
+            // 開始時は true、停止リクエスト時は false を返す
+            expect(handler.toggleRecording()).toBe(true);
+            expect(handler.toggleRecording()).toBe(false);
+        });
+
+        it('should not enter recording state and should report an error when start throws', () => {
+            const { handler, opts } = setup();
+            const rec = createdRecognitions[0];
+            rec.start.mockImplementationOnce(() => {
+                throw new Error('InvalidStateError');
+            });
+
+            // start が失敗したら録音状態にならず false を返す
+            expect(handler.toggleRecording()).toBe(false);
+            expect(opts.onError).toHaveBeenCalledWith(expect.any(Error));
+
+            // 状態がずれていないので、次の toggle で再度 start を試みられる
+            expect(handler.toggleRecording()).toBe(true);
+            expect(rec.start).toHaveBeenCalledTimes(2);
+        });
+
         it('should preview interim results without sending, then deliver the final text once on end', () => {
             const { opts } = setup();
             const rec = createdRecognitions[0];

--- a/widget/utils/audioHandler.test.ts
+++ b/widget/utils/audioHandler.test.ts
@@ -186,6 +186,49 @@ describe('initAudioHandler', () => {
         });
     });
 
+    describe('recording suppresses playback (barge-in)', () => {
+        it('should stop the bot voice when recording starts', async () => {
+            const { handler } = setup();
+            // ボットが発話中
+            handler.handleAudioChunk(new ArrayBuffer(2));
+            await flush();
+            expect(createdSources).toHaveLength(1);
+
+            // 発話中にマイクを押す（録音開始）と再生中の音声を止める
+            handler.toggleRecording();
+            expect(createdSources[0].stop).toHaveBeenCalled();
+        });
+
+        it('should not play audio chunks that arrive while recording', async () => {
+            const { handler } = setup();
+            handler.toggleRecording(); // 録音開始
+            handler.handleAudioChunk(new ArrayBuffer(2));
+            await flush();
+            // 録音中はボットの発話を再生しない（マイクが自分の音声を拾わないように）
+            expect(createdSources).toHaveLength(0);
+        });
+
+        it('should abort a chunk that finishes decoding after recording starts', async () => {
+            const { handler } = setup();
+            handler.handleAudioChunk(new ArrayBuffer(2));
+            // decode の待機中（await 前）に録音を開始する
+            handler.toggleRecording();
+            await flush();
+            // decode 完了後も再生（source 生成）されない
+            expect(createdSources).toHaveLength(0);
+        });
+
+        it('should resume playing after recording stops', async () => {
+            const { handler } = setup();
+            const rec = createdRecognitions[0];
+            handler.toggleRecording(); // 録音開始
+            rec.onend!(); // 録音終了（onend で isRecording が false になる）
+            handler.handleAudioChunk(new ArrayBuffer(2));
+            await flush();
+            expect(createdSources).toHaveLength(1);
+        });
+    });
+
     describe('speech recognition', () => {
         it('should report support correctly', () => {
             const { handler } = setup();

--- a/widget/utils/audioHandler.ts
+++ b/widget/utils/audioHandler.ts
@@ -76,6 +76,8 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
 
   async function playNextInQueue(): Promise<void> {
     if (isPlaying || audioQueue.length === 0) return;
+    // 録音中はボットの発話を再生しない（マイクが自分の音声を拾うのを防ぐ）
+    if (isRecording) return;
     if (!audioContext) initAudioContext();
     if (!audioContext) return;
 
@@ -88,6 +90,12 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
         const audioBuffer = await audioContext.decodeAudioData(
           rawData.slice(0),
         );
+
+        // decode の待機中に録音が開始された場合は再生を中止する
+        if (isRecording) {
+          isPlaying = false;
+          return;
+        }
 
         const source = audioContext.createBufferSource();
         source.buffer = audioBuffer;
@@ -115,6 +123,9 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
   }
 
   function handleAudioChunk(content: unknown): void {
+    // 録音中はボットの発話を再生しない（マイクが自分の音声を拾うのを防ぐ）
+    if (isRecording) return;
+
     let rawData: ArrayBuffer;
 
     if (content instanceof ArrayBuffer) {
@@ -208,6 +219,10 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
     if (isRecording) {
       recognition.stop();
     } else {
+      // 録音開始時に再生中のボット音声を止める。
+      // これにより「発話中にマイクを押すと発話が止まり、
+      // ボットの音声がテキスト化されて入力欄に入る」問題を防ぐ。
+      resetAudioState();
       finalTranscript = "";
       recognition.start();
       isRecording = true;

--- a/widget/utils/audioHandler.ts
+++ b/widget/utils/audioHandler.ts
@@ -21,8 +21,8 @@ export interface AudioHandler {
   resumeAudioContext: () => Promise<void>;
   /** 再生中の音声を停止してキューをクリアする */
   resetAudioState: () => void;
-  /** 音声認識を開始/停止トグルする */
-  toggleRecording: () => void;
+  /** 音声認識を開始/停止トグルする。トグル後に録音中なら true を返す。 */
+  toggleRecording: () => boolean;
   /** 音声認識が利用可能かどうか */
   isSpeechRecognitionSupported: () => boolean;
   /** リソースを解放する */
@@ -213,20 +213,31 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
     };
   }
 
-  function toggleRecording(): void {
-    if (!recognition) return;
+  function toggleRecording(): boolean {
+    if (!recognition) return false;
 
     if (isRecording) {
+      // 停止をリクエストする。isRecording は onend で false になる。
       recognition.stop();
-    } else {
-      // 録音開始時に再生中のボット音声を止める。
-      // これにより「発話中にマイクを押すと発話が止まり、
-      // ボットの音声がテキスト化されて入力欄に入る」問題を防ぐ。
-      resetAudioState();
-      finalTranscript = "";
-      recognition.start();
-      isRecording = true;
+      return false;
     }
+
+    // 録音開始時に再生中のボット音声を止める。
+    // これにより「発話中にマイクを押すと発話が止まり、
+    // ボットの音声がテキスト化されて入力欄に入る」問題を防ぐ。
+    resetAudioState();
+    finalTranscript = "";
+    try {
+      recognition.start();
+    } catch (e) {
+      // すでに開始済み等で start() が失敗した場合は録音状態にしない。
+      // （ボタン表示と実状態がずれるのを防ぐ）
+      isRecording = false;
+      onError?.(e instanceof Error ? e : new Error(String(e)));
+      return false;
+    }
+    isRecording = true;
+    return true;
   }
 
   function isSpeechRecognitionSupported(): boolean {

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -63,6 +63,7 @@ function getEls() {
         input: shadow.querySelector('.text-input') as HTMLTextAreaElement,
         sendBtn: shadow.querySelector('.send-btn') as HTMLButtonElement,
         micBtn: shadow.querySelector('.mic-btn') as HTMLButtonElement,
+        audioToggleBtn: shadow.querySelector('.audio-toggle-btn') as HTMLButtonElement,
         launcherBtn: shadow.querySelector('.launcher-button') as HTMLButtonElement,
         closeBtn: shadow.querySelector('.close-btn') as HTMLButtonElement,
         loadingOverlay: shadow.querySelector('.loading-overlay') as HTMLElement,
@@ -396,6 +397,43 @@ describe('initChatWidget (rich UI)', () => {
             micBtn.click();
             expect(window.alert).toHaveBeenCalled();
             expect(audioHandler.toggleRecording).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('audio output toggle', () => {
+        it('is off by default and turning it on makes typed messages use TTS', () => {
+            initChatWidget({ language: 'ja' });
+            const { audioToggleBtn, input, sendBtn } = getEls();
+            expect(audioToggleBtn.getAttribute('aria-pressed')).toBe('false');
+
+            audioToggleBtn.click();
+            expect(audioToggleBtn.getAttribute('aria-pressed')).toBe('true');
+
+            input.value = 'hello';
+            sendBtn.click();
+            // 音声出力 ON のときはテキスト送信でも useAudio=true になる
+            expect(socketHandler.sendUserInput).toHaveBeenCalledWith('hello', true, 'ja');
+        });
+
+        it('turning it off stops current playback and reverts typed messages to text', () => {
+            initChatWidget({ language: 'ja' });
+            const { audioToggleBtn, input, sendBtn } = getEls();
+            audioToggleBtn.click(); // ON
+            audioToggleBtn.click(); // OFF
+            expect(audioToggleBtn.getAttribute('aria-pressed')).toBe('false');
+            // OFF にしたら再生中の音声を止める
+            expect(audioHandler.resetAudioState).toHaveBeenCalled();
+
+            input.value = 'hello';
+            sendBtn.click();
+            expect(socketHandler.sendUserInput).toHaveBeenCalledWith('hello', false, 'ja');
+        });
+
+        it('is enabled automatically when the mic is used', () => {
+            initChatWidget();
+            const { micBtn, audioToggleBtn } = getEls();
+            micBtn.click(); // 録音開始 → isAudioEnabled = true
+            expect(audioToggleBtn.getAttribute('aria-pressed')).toBe('true');
         });
     });
 

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -413,6 +413,35 @@ describe('initChatWidget (rich UI)', () => {
             expect(msgs[msgs.length - 1].innerHTML).toContain('マイク');
         });
 
+        it('mic click should not mark recording or enable audio when start fails', () => {
+            // start() が失敗すると toggleRecording は false を返す
+            audioHandler.toggleRecording.mockReturnValue(false);
+            initChatWidget();
+            const { micBtn, audioToggleBtn } = getEls();
+
+            micBtn.click();
+
+            expect(audioHandler.toggleRecording).toHaveBeenCalled();
+            // 実状態が録音中でないのでボタン表示も録音中にならず、音声出力も自動有効化しない
+            expect(micBtn.classList.contains('recording')).toBe(false);
+            expect(audioToggleBtn.getAttribute('aria-pressed')).toBe('false');
+        });
+
+        it('onError should surface device and network messages', () => {
+            initChatWidget({ language: 'ja' });
+            const { timeline } = getEls();
+            const lastServerMsg = () => {
+                const msgs = timeline.querySelectorAll('.message.makasete-server');
+                return msgs[msgs.length - 1].innerHTML;
+            };
+
+            captured.audioOpts!.onError!(new Error('audio-capture'));
+            expect(lastServerMsg()).toContain('マイクが見つかりません');
+
+            captured.audioOpts!.onError!(new Error('network'));
+            expect(lastServerMsg()).toContain('ネットワーク');
+        });
+
         it('onError should stay silent for benign no-speech errors', () => {
             initChatWidget();
             const { timeline } = getEls();

--- a/widget/widget.test.ts
+++ b/widget/widget.test.ts
@@ -12,6 +12,7 @@ interface CapturedSocketOpts {
 interface CapturedAudioOpts {
     onTranscript: (text: string) => void;
     onRecordingEnd: (finalText: string) => void;
+    onError?: (error: Error) => void;
     language?: string;
 }
 
@@ -76,6 +77,7 @@ describe('initChatWidget (rich UI)', () => {
         document.body.style.overflow = '';
         vi.clearAllMocks();
         audioHandler.isSpeechRecognitionSupported.mockReturnValue(true);
+        audioHandler.toggleRecording.mockReturnValue(true);
         audioHandler.resumeAudioContext.mockReturnValue(Promise.resolve());
         window.alert = vi.fn();
         // fetch(/health) はローディング解除、fetch(/api/settings) は設定取得に使われる。
@@ -397,6 +399,35 @@ describe('initChatWidget (rich UI)', () => {
             micBtn.click();
             expect(window.alert).toHaveBeenCalled();
             expect(audioHandler.toggleRecording).not.toHaveBeenCalled();
+        });
+
+        it('onError should surface a permission message and clear the recording indicator', () => {
+            initChatWidget({ language: 'ja' });
+            const { micBtn, timeline } = getEls();
+            micBtn.classList.add('recording');
+
+            captured.audioOpts!.onError!(new Error('not-allowed'));
+
+            expect(micBtn.classList.contains('recording')).toBe(false);
+            const msgs = timeline.querySelectorAll('.message.makasete-server');
+            expect(msgs[msgs.length - 1].innerHTML).toContain('マイク');
+        });
+
+        it('onError should stay silent for benign no-speech errors', () => {
+            initChatWidget();
+            const { timeline } = getEls();
+            const before = timeline.querySelectorAll('.message.makasete-server').length;
+            captured.audioOpts!.onError!(new Error('no-speech'));
+            const after = timeline.querySelectorAll('.message.makasete-server').length;
+            expect(after).toBe(before);
+        });
+
+        it('onError should show a generic English message for unknown errors', () => {
+            initChatWidget({ language: 'en' });
+            const { timeline } = getEls();
+            captured.audioOpts!.onError!(new Error('some-unknown-error'));
+            const msgs = timeline.querySelectorAll('.message.makasete-server');
+            expect(msgs[msgs.length - 1].innerHTML.toLowerCase()).toContain('speech recognition');
         });
     });
 

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -151,6 +151,39 @@ export function initChatWidget(config: WidgetConfig = {}): void {
         sendMessage(true);
       }
     },
+    onError: (error) => {
+      // 音声認識のエラーをユーザーに通知する。
+      // no-speech / aborted は通常操作の範囲なので通知しない。
+      const code = error.message;
+      if (code === "no-speech" || code === "aborted") return;
+
+      let message: string;
+      switch (code) {
+        case "not-allowed":
+        case "service-not-allowed":
+          message = isEn
+            ? "Microphone access is blocked. Please allow it in your browser settings."
+            : "マイクの使用が許可されていません。ブラウザの設定をご確認ください。";
+          break;
+        case "audio-capture":
+          message = isEn
+            ? "No microphone was found. Please check your device."
+            : "マイクが見つかりませんでした。デバイスをご確認ください。";
+          break;
+        case "network":
+          message = isEn
+            ? "A network error occurred during speech recognition."
+            : "音声認識中にネットワークエラーが発生しました。";
+          break;
+        default:
+          message = isEn
+            ? "Speech recognition failed. Please try again."
+            : "音声認識でエラーが発生しました。もう一度お試しください。";
+      }
+      // 録音表示が残らないように解除してからメッセージを表示する
+      els.micBtn.classList.remove("recording");
+      appendMessage(els.timeline, messageState, "makasete-server", message);
+    },
     language,
   });
 
@@ -244,8 +277,10 @@ export function initChatWidget(config: WidgetConfig = {}): void {
     }
     audio.resumeAudioContext().catch(console.error);
     audio.initAudioContext();
-    audio.toggleRecording();
-    const recording = els.micBtn.classList.toggle("recording");
+    // 実際の録音状態に合わせてボタン表示を更新する
+    // （start() が失敗した場合に表示だけ録音中になるのを防ぐ）
+    const recording = audio.toggleRecording();
+    els.micBtn.classList.toggle("recording", recording);
     // マイク利用開始時にボットの音声出力も自動で有効化する
     if (recording) {
       isAudioEnabled = true;

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -21,6 +21,11 @@ interface WidgetConfig {
   language?: "ja" | "en";
 }
 
+/** 音声読み上げ ON（スピーカー）アイコン */
+const ICON_AUDIO_ON = `<svg class="lucide lucide-volume-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/></svg>`;
+/** 音声読み上げ OFF（ミュート）アイコン */
+const ICON_AUDIO_OFF = `<svg class="lucide lucide-volume-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="22" x2="16" y1="9" y2="15"/><line x1="16" x2="22" y1="9" y2="15"/></svg>`;
+
 /** ウィジェットのリッチUIマークアップ（ランチャーボタン・チャットウィンドウ等） */
 function buildWidgetMarkup(placeholder: string, helperText: string): string {
   return `
@@ -29,6 +34,9 @@ function buildWidgetMarkup(placeholder: string, helperText: string): string {
         <div class="chat-header">
           <span class="chat-title"></span>
           <div class="header-controls">
+            <button class="audio-toggle-btn" aria-pressed="false">
+              ${ICON_AUDIO_OFF}
+            </button>
             <button class="close-btn" title="閉じる">
               <svg class="lucide lucide-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
             </button>
@@ -108,6 +116,24 @@ export function initChatWidget(config: WidgetConfig = {}): void {
   let isAudioEnabled = false;
   // ドラッグ操作中かどうか（ランチャーのクリック判定で使用）
   let isDragging = false;
+
+  // 音声読み上げ ON/OFF トグルボタン（ヘッダー内）
+  const audioToggleBtn = shadow.querySelector(
+    ".audio-toggle-btn",
+  ) as HTMLButtonElement;
+
+  /** トグルボタンの表示（アイコン・タイトル・aria）を現在の状態に合わせて更新する */
+  function updateAudioToggle(): void {
+    audioToggleBtn.innerHTML = isAudioEnabled ? ICON_AUDIO_ON : ICON_AUDIO_OFF;
+    audioToggleBtn.setAttribute("aria-pressed", String(isAudioEnabled));
+    audioToggleBtn.title = isAudioEnabled
+      ? isEn
+        ? "Turn voice replies off"
+        : "音声読み上げをオフにする"
+      : isEn
+        ? "Turn voice replies on"
+        : "音声読み上げをオンにする";
+  }
 
   // --- Audio ---
   const audio: AudioHandler = initAudioHandler({
@@ -221,8 +247,26 @@ export function initChatWidget(config: WidgetConfig = {}): void {
     audio.toggleRecording();
     const recording = els.micBtn.classList.toggle("recording");
     // マイク利用開始時にボットの音声出力も自動で有効化する
-    if (recording) isAudioEnabled = true;
+    if (recording) {
+      isAudioEnabled = true;
+      updateAudioToggle();
+    }
   });
+
+  // 音声読み上げの ON/OFF を手動で切り替える。
+  // OFF にしたときは再生中の音声も止める。
+  audioToggleBtn.addEventListener("click", () => {
+    isAudioEnabled = !isAudioEnabled;
+    if (isAudioEnabled) {
+      audio.resumeAudioContext().catch(console.error);
+    } else {
+      audio.resetAudioState();
+    }
+    updateAudioToggle();
+  });
+
+  // 初期表示（アイコン・タイトル）を状態に合わせて設定する
+  updateAudioToggle();
 
   els.launcherBtn.addEventListener("click", () => {
     if (isDragging) return; // ドラッグ中はトグルしない


### PR DESCRIPTION
## 概要

音声チャットの不具合修正と、関連する懸念点への対応をまとめたPRです。

### 1.【元の不具合】発話中にマイクを押すとボット音声がテキスト化される
チャットボットが発話（TTS 再生）中にマイクボタンを押すと、音声認識がボット自身の音声を拾い、そのままテキスト化されて入力欄に入ってしまう問題を修正しました。マイクを押すとボットの発話が止まり、録音中はボット音声を再生しないようにします（バージイン動作）。

**`widget/utils/audioHandler.ts`**
- `toggleRecording()` の録音開始時に `resetAudioState()` を呼び、再生中のボット音声を停止。
- `handleAudioChunk()` / `playNextInQueue()` は録音中にTTSを再生しない。`decodeAudioData` の待機中に録音が開始されたケースでも再生を中止（レース対策）。

### 2.【追加対応】バージイン時に進行中のサーバー応答をキャンセル
発話中に割り込んで新しい入力を送った場合、これまではサーバー側の応答生成が止まらず、テキストが混在表示されたり、同一ソケット上で応答が二重実行され `chatHistory` やイベントが交錯する懸念がありました。

**`server/services/chat.ts`**
- `activeGeneration` を導入し、新しい入力が来たら進行中の応答を無効化。テキスト/音声の送信・履歴追加・`response-complete` を停止し、割り込まれた応答は履歴に残さず TTS 音声も破棄します。

### 3.【追加対応】音声読み上げ ON/OFF のトグルUI
一度マイクを使うと `isAudioEnabled` が固定され、以後のテキスト送信もすべてTTSになり、解除する手段がありませんでした。

**`widget/widget.ts`**
- ヘッダーに音声読み上げの ON/OFF トグルボタンを追加（既存の未使用スタイル `.audio-toggle-btn` を利用）。OFF にしたときは再生中の音声も停止します。マイク利用時は従来どおり自動でONになり、ボタン表示にも反映されます。

## テスト

- `widget/utils/audioHandler.test.ts`: バージイン抑止のテストを追加
- `server/services/chat.test.ts`: 応答キャンセルのテストを追加
- `widget/widget.test.ts`: 音声出力トグルのテストを追加

## 動作確認

- `pnpm test` : 188 件すべて成功
- `pnpm typecheck` : 成功
- `pnpm lint` : 成功
- `pnpm build:widget` : 成功。ヘッドレスブラウザでトグルボタンの表示切替（volume-x ⇄ volume-2 / aria-pressed / title）を目視確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173bcihSf2k5nSdpQBGSqLE