### PR TITLE
feat(tts): switch Chirp 3 HD voice to Aoede and bump speaking rate

### DIFF
--- a/server/services/tts/google.test.ts
+++ b/server/services/tts/google.test.ts
@@ -87,7 +87,8 @@ describe('GeminiTTSService', () => {
 
         const reqBody = synthesize.mock.calls[0][0].requestBody;
         expect(reqBody.input).toEqual({ text: 'こんにちは' });
-        expect(reqBody.voice).toEqual({ languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Kore' });
+        expect(reqBody.voice).toEqual({ languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Aoede' });
+        expect(reqBody.audioConfig).toEqual({ audioEncoding: 'MP3', speakingRate: 1.15 });
 
         const chunks: Buffer[] = [];
         for await (const c of stream) chunks.push(c as Buffer);
@@ -103,7 +104,7 @@ describe('GeminiTTSService', () => {
 
         const reqBody = synthesize.mock.calls[0][0].requestBody;
         expect(reqBody.input).toEqual({ ssml: '<speak>hi</speak>' });
-        expect(reqBody.voice).toEqual({ languageCode: 'en-US', name: 'en-US-Chirp3-HD-Kore' });
+        expect(reqBody.voice).toEqual({ languageCode: 'en-US', name: 'en-US-Chirp3-HD-Aoede' });
     });
 
     it('should fall back to the Japanese voice for unknown languages', async () => {

--- a/server/services/tts/google.ts
+++ b/server/services/tts/google.ts
@@ -38,12 +38,16 @@ export class GeminiTTSService implements TTSService {
 
     // Chirp 3: HD voices — the latest high-fidelity generation, suitable for
     // low-latency real-time synthesis. Voice names are shared across locales
-    // in the <locale>-Chirp3-HD-<voice> format. "Kore" is a calm, composed
+    // in the <locale>-Chirp3-HD-<voice> format. "Aoede" is a bright, friendly
     // voice that fits customer-support / help-desk / FAQ use cases.
     private static readonly VOICES: Record<string, texttospeech_v1.Schema$VoiceSelectionParams> = {
-        ja: { languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Kore' },
-        en: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Kore' },
+        ja: { languageCode: 'ja-JP', name: 'ja-JP-Chirp3-HD-Aoede' },
+        en: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Aoede' },
     };
+
+    // Slightly faster-than-normal pace for a snappier response feel. Chirp 3: HD
+    // voices support speakingRate in the 0.25–2.0 range (1.0 = normal speed).
+    private static readonly SPEAKING_RATE = 1.15;
 
     public async generateSpeechStream(text: string, language = 'ja'): Promise<Readable> {
         const client = await this.getClient();
@@ -56,10 +60,11 @@ export class GeminiTTSService implements TTSService {
                     requestBody: {
                         input: isSsml ? { ssml: text } : { text },
                         voice,
-                        // Note: Chirp 3 HD voices do not support the speakingRate
-                        // (or pitch) parameter, so it is intentionally omitted.
+                        // Note: Chirp 3 HD voices support speakingRate but not
+                        // pitch, so only the rate is set here.
                         audioConfig: {
                             audioEncoding: 'MP3',
+                            speakingRate: GeminiTTSService.SPEAKING_RATE,
                         },
                     }
                 }, (err, res) => {


### PR DESCRIPTION
## 概要

TTS の音声を Kore から Aoede に変更し、読み上げ速度を少し上げました。

## 変更内容

- `server/services/tts/google.ts`
  - ja-JP / en-US の Chirp 3 HD 音声を `Kore` → `Aoede` に変更
  - `speakingRate` を `1.15` に設定（Chirp 3 HD は 0.25〜2.0 の範囲で速度調整に対応）。以前は「速度変更非対応」としてコメントで省略していたが、対応済みのため有効化
- `server/services/tts/google.test.ts`
  - 新しい音声名と `audioConfig.speakingRate` を検証するようにテストを更新

## 確認事項

- `pnpm vitest run server/services/tts/google.test.ts` — 10 件すべてパス
- `pnpm typecheck` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U85c6MH6HfkHm3DaQS6SQA)_