### PR TITLE
fix(tts): 篭った音声を解消するため1文を完結MP3として送信

### DIFF
--- a/server/services/chat.test.ts
+++ b/server/services/chat.test.ts
@@ -175,6 +175,41 @@ describe('ChatService', () => {
             expect(audioEmits).toHaveLength(2);
         });
 
+        it('should emit a multi-chunk TTS stream as a single concatenated audio chunk', async () => {
+            // MP3 must not be split at arbitrary byte boundaries, so a sentence
+            // whose TTS stream arrives in several parts must be emitted as one
+            // complete MP3 rather than one audio-chunk per stream part.
+            generateResponseStream.mockResolvedValue(makeStream(['やあ。']));
+            generateSpeechStream.mockResolvedValue(
+                Readable.from([Buffer.from('AU'), Buffer.from('DI'), Buffer.from('O')]),
+            );
+            const socket = makeSocket();
+            const svc = new ChatService();
+
+            await svc.handleUserInput(socket as never, { text: 'hi', isVoiceInput: true });
+
+            const audioEmits = socket.emit.mock.calls.filter(
+                (c) => c[0] === 'audio-chunk' && c[1].type === 'audio',
+            );
+            // 断片ごとではなく1文=1チャンクで送信される
+            expect(audioEmits).toHaveLength(1);
+            expect((audioEmits[0][1].content as Buffer).toString()).toBe('AUDIO');
+        });
+
+        it('should not emit an audio chunk for an empty TTS stream', async () => {
+            generateResponseStream.mockResolvedValue(makeStream(['やあ。']));
+            generateSpeechStream.mockResolvedValue(Readable.from([]));
+            const socket = makeSocket();
+            const svc = new ChatService();
+
+            await svc.handleUserInput(socket as never, { text: 'hi', isVoiceInput: true });
+
+            const audioEmits = socket.emit.mock.calls.filter(
+                (c) => c[0] === 'audio-chunk' && c[1].type === 'audio',
+            );
+            expect(audioEmits).toHaveLength(0);
+        });
+
         it('should apply SSML pause breaks for Google TTS', async () => {
             getTTSService.mockReturnValueOnce({ generateSpeechStream, getName: () => 'gemini-tts' });
             generateResponseStream.mockResolvedValue(makeStream(['やあ。']));

--- a/server/services/chat.ts
+++ b/server/services/chat.ts
@@ -12,9 +12,6 @@ import {
 } from "../utils/text";
 import { getRecommendations } from "./recommendations";
 
-// Minimum audio chunk size for reliable MP3 decoding in browsers (~0.25s at 128kbps)
-const MIN_AUDIO_CHUNK_BYTES = 4 * 1024;
-
 export class ChatService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private chatHistory: any[] = [];
@@ -150,8 +147,15 @@ export class ChatService {
     }
   }
 
-  // Resumes a paused audio stream and forwards its data to the socket in
-  // minimum-size chunks for reliable MP3 decoding on the client.
+  // Resumes a paused audio stream, buffers it in full, and forwards the whole
+  // sentence's audio to the socket as a single "audio-chunk".
+  //
+  // The audio is MP3, which cannot be split at arbitrary byte boundaries: MP3's
+  // bit reservoir stores a frame's high-frequency data in preceding frames, so
+  // decoding a mid-stream byte slice on its own loses those highs and sounds
+  // muffled (plus clicks/gaps at frame-desynced boundaries). The client decodes
+  // each "audio-chunk" as a self-contained MP3 via decodeAudioData, so we must
+  // send one complete MP3 per sentence rather than partial slices.
   private async drainStreamToSocket(
     socket: Socket,
     streamPromise: Promise<NodeJS.ReadableStream | null>,
@@ -160,19 +164,18 @@ export class ChatService {
     if (!audioStream) return;
 
     await new Promise<void>((resolve) => {
-      let pending = Buffer.alloc(0);
+      const chunks: Buffer[] = [];
 
       audioStream.on("data", (chunk: Buffer) => {
-        pending = Buffer.concat([pending, chunk]);
-        if (pending.length >= MIN_AUDIO_CHUNK_BYTES) {
-          socket.emit("audio-chunk", { type: "audio", content: pending });
-          pending = Buffer.alloc(0);
-        }
+        chunks.push(chunk);
       });
 
       audioStream.on("end", () => {
-        if (pending.length > 0) {
-          socket.emit("audio-chunk", { type: "audio", content: pending });
+        if (chunks.length > 0) {
+          const full = Buffer.concat(chunks);
+          if (full.length > 0) {
+            socket.emit("audio-chunk", { type: "audio", content: full });
+          }
         }
         resolve();
       });


### PR DESCRIPTION
## 概要

TTS の再生音が「篭った/くぐもった (muffled)」聞こえ方になる問題を修正します。

## 原因

現在の音声パイプラインは以下の通りでした:

1. Google Cloud TTS (`server/services/tts/google.ts`) は **1文分を1つの完結した MP3 バッファ**として同期的に返す（真のストリーミングではなく全バイトが一度に揃う）。
2. `server/services/chat.ts` の `drainStreamToSocket` が、その 1 つの MP3 を **任意の 4KB バイト境界で分割**して `audio-chunk` として送信していた（分割位置は MP3 フレーム境界と無関係）。
3. クライアント `widget/utils/audioHandler.ts` が、各断片を **独立した完結 MP3 として `decodeAudioData`** していた。

MP3 は bit reservoir（各フレームの高域データを直前フレームのバイト領域に格納する仕組み）を持つため、フレーム境界を無視した途中断片を単体デコードすると先行フレームのリザーバが欠落して**高域が復元されず**、「篭った」音になっていました。加えてフレーム同期を持たない中間断片は境界でのプチプチ音・ギャップも生んでいました。

## 変更内容

- `server/services/chat.ts`
  - `drainStreamToSocket` を、ストリーム全体をバッファリングして **`end` 時に1回だけ完結 MP3 を `audio-chunk` として送信**する形に変更。途中の 4KB 分割送信を廃止。
  - 誤解を招く `MIN_AUDIO_CHUNK_BYTES` 定数とコメントを削除し、意図を説明するコメントを追加。
- クライアント (`widget/utils/audioHandler.ts`) は既に「1 つの `audio-chunk` = 1 つの完結 MP3」としてデコードしているため**変更不要**。
- `server/services/chat.test.ts`
  - 複数チャンクのストリームが**1回の結合された `audio-chunk`** として送信されること、空ストリームでは送信されないことを検証するテストを追加。

## 遅延への影響

Google TTS（デフォルト）は元々 1 文分の MP3 を一括で返すため、**遅延の増加はありません**（句読点ベースの文単位ストリーミングは維持）。

## テスト

- `pnpm test` — 全 199 テスト通過
- `pnpm typecheck` — エラーなし
- `pnpm lint` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014igz1UiWY27YXw9TNCiUYD)_