### PR TITLE
fix(socket): Firebase の末尾スラッシュ除去による socket.io 404 を解消

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -52,6 +52,12 @@ const io = new Server(httpServer, {
     origin: allowedOrigins,
     methods: ["GET", "POST"],
   },
+  // Firebase App Hosting (Cloud Run 前段のプロキシ) は末尾スラッシュを除去して
+  // リクエストを転送するため、既定の `/socket.io/` では engine.io がパスを
+  // 認識できず 404 になる。`addTrailingSlash: false` で `/socket.io`（末尾
+  // スラッシュ無し）も受け付けるようにし、どちらの形式でもハンドシェイクを
+  // 成立させる。
+  addTrailingSlash: false,
 });
 
 // Security: Simple Socket.io rate limiting

--- a/widget/utils/socketHandler.test.ts
+++ b/widget/utils/socketHandler.test.ts
@@ -37,9 +37,13 @@ describe('initSocketHandler', () => {
         return { handler, cbs };
     }
 
-    it('should connect to the provided server url', () => {
+    it('should connect to the provided server url without a trailing slash', () => {
         setup();
-        expect(ioMock).toHaveBeenCalledWith('http://localhost');
+        // addTrailingSlash: false を明示し、末尾スラッシュを除去するプロキシ
+        // (Firebase App Hosting 等) の背後でも 404 にならないようにする。
+        expect(ioMock).toHaveBeenCalledWith('http://localhost', {
+            addTrailingSlash: false,
+        });
     });
 
     it('should route socket events to the corresponding callbacks', () => {

--- a/widget/utils/socketHandler.ts
+++ b/widget/utils/socketHandler.ts
@@ -30,7 +30,10 @@ export function initSocketHandler(
 ): SocketHandler {
   const { serverUrl, onTextChunk, onAudioChunk, onError, onConnect, onResponseComplete, onRecommendation } = options;
 
-  const socket: Socket = io(serverUrl);
+  // Firebase App Hosting などのプロキシは既定の `/socket.io/` から末尾スラッシュを
+  // 除去して転送し、サーバ側でパスが一致せず 404 になることがある。クライアント側でも
+  // 末尾スラッシュを付けずに接続し、サーバの設定と揃える。
+  const socket: Socket = io(serverUrl, { addTrailingSlash: false });
 
   socket.on("connect", () => {
     onConnect?.();


### PR DESCRIPTION
## 概要 (Summary)

ウィジェット埋め込み時に発生していた `/socket.io?EIO=4&transport=polling&...` への **404 エラー大量発生**と、「サイトでは読み込めるがチャット会話ができない」問題を修正します。

## 原因 (Root Cause)

Socket.io の接続は次の経路をたどります:

1. **クライアント** (`socket.io-client` / `engine.io-client@6.6.4`) は既定で `addTrailingSlash: true` のため、末尾スラッシュ付きの `/socket.io/?EIO=4&transport=polling` へ接続します。
2. **Firebase App Hosting** (ログの `labels.goog-managed-by: firebase-app-hosting`。Cloud Run の前段プロキシ) が **末尾スラッシュを除去**し、`/socket.io?EIO=4&transport=polling` として Cloud Run へ転送します。
3. **サーバ** (`engine.io@6.6.5`) のパス判定は `path === req.url.slice(0, path.length)` で、`path` は既定で `/socket.io/`。転送されてくる `/socket.io?...` は先頭 11 文字が `/socket.io?` となり `/socket.io/` と一致しません。
4. その結果 engine.io がリクエストを処理せず Express へフォールスルーし、該当ルートが無いため **404** を返します。ハンドシェイクが成立しないため、ウィジェット自体は読み込めても**チャット接続 (WebSocket) が確立できません**。

> ログの `httpRequest.userAgent: "Google"` / `remoteIp` が Google IP なのは、Firebase App Hosting のエッジが Cloud Run オリジンへ代理リクエストしているためで、別問題ではありません。

## 修正内容 (Changes)

サーバ・クライアント双方で `addTrailingSlash: false` を指定し、末尾スラッシュ無しの `/socket.io` でハンドシェイクを成立させます。

- **`server/index.ts`**: `new Server(httpServer, { …, addTrailingSlash: false })`
  - engine.io のパスが `/socket.io` になり、`slice(0, 10)` 判定により **`/socket.io` と `/socket.io/` の両形式**を受け付けます (プロキシで除去された形式・生クライアントの形式のどちらでも成立し、キャッシュ済みの旧ウィジェットも救済)。
- **`widget/utils/socketHandler.ts`**: `io(serverUrl, { addTrailingSlash: false })`
  - クライアントが最初から末尾スラッシュを付けずに接続し、プロキシの挙動に依存しないようにします (Socket.io 公式がプロキシ環境で推奨するパターン)。
- **`widget/utils/socketHandler.test.ts`**: `io()` 呼び出し引数の期待値を更新。

## 検証 (Verification)

Firebase App Hosting の末尾スラッシュ除去を再現した最小サーバで確認しました:

| リクエスト | 既定 (現行) | 修正後 (`addTrailingSlash: false`) |
| --- | --- | --- |
| `GET /socket.io?...` (プロキシ除去後) | **404** ❌ (報告された不具合) | **200** ✅ ハンドシェイク成立 |
| `GET /socket.io/?...` (生クライアント) | 200 ✅ | **200** ✅ (後方互換) |

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (16 files / 199 tests passed)

## 補足 (Note / Out of scope)

本 PR は報告された 404 の根本原因 (末尾スラッシュ) を解消するものです。別途、`widget/main.ts` の `serverUrl: window.location.origin` は「バックエンドと同一オリジンで配信されるページ」を前提としており、将来的に**第三者サイトへ埋め込む**場合は固定のバックエンド URL (例: `VITE_SERVER_URL`) を用いる必要があります。今回のログは同一オリジン (`makasete-ai.nisyuu.com`) からの接続で、原因は末尾スラッシュのみのため、既存の動作を壊さないよう本 PR では変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2FXGcmN7WFR3SgZKaV4GD

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2FXGcmN7WFR3SgZKaV4GD)_