### PR TITLE
fix(widget): 埋め込みサイトで socket.io が 404 を返し続ける問題を解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ ECサイトの `</body>` タグの直前に以下のスクリプトを追加し�
 <script src="https://[YOUR_CLOUD_RUN_URL]/public/widget.js"></script>
 ```
 
+ウィジェットは既定で **スクリプトの読み込み元（= Cloud Run の URL）** に接続します。埋め込み先サイトのドメインには接続しないため、上記のタグを追加するだけで動作します。
+
+接続先を明示的に指定したい場合は `data-server-url` 属性を使用してください。
+
+```html
+<script
+  src="https://[YOUR_CLOUD_RUN_URL]/public/widget.js"
+  data-server-url="https://[YOUR_CLOUD_RUN_URL]"
+></script>
+```
+
+> **注意**: 埋め込み先サイトからの接続はクロスオリジンになるため、サーバー側の環境変数 `ALLOWED_ORIGINS` に埋め込み先サイトの origin（例: `https://example.com`）を含める必要があります。
+
 ## スプレッドシートの構成
 
 本システムは、指定された `GOOGLE_SHEETS_ID` のスプレッドシートから以下のシートを参照します。各シートの1行目はヘッダーとして扱われます。**カラム名や数は自由に追加・変更が可能**です（AIが自動的に読み込みます）。

--- a/widget/main.ts
+++ b/widget/main.ts
@@ -1,6 +1,9 @@
 import { initChatWidget } from "./widget";
+import { resolveServerUrl } from "./utils/serverUrl";
 
 initChatWidget({
-  serverUrl: window.location.origin,
+  // トップレベルの同期呼び出しを維持する（script 評価中でないと
+  // document.currentScript から配信元 origin を導出できない）。
+  serverUrl: resolveServerUrl(),
   language: "ja",
 });

--- a/widget/utils/serverUrl.test.ts
+++ b/widget/utils/serverUrl.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import { resolveServerUrl } from "./serverUrl";
+
+function createScript(attrs: {
+  src?: string;
+  serverUrl?: string;
+}): HTMLScriptElement {
+  const script = document.createElement("script");
+  if (attrs.src !== undefined) {
+    script.setAttribute("src", attrs.src);
+  }
+  if (attrs.serverUrl !== undefined) {
+    script.setAttribute("data-server-url", attrs.serverUrl);
+  }
+  return script;
+}
+
+describe("resolveServerUrl", () => {
+  const fallbackOrigin = "http://fallback.example";
+
+  it("should use the data-server-url attribute when present", () => {
+    const script = createScript({
+      src: "https://cdn.example/public/widget.js",
+      serverUrl: "https://api.example.com",
+    });
+    expect(resolveServerUrl({ currentScript: script, fallbackOrigin })).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("should normalize data-server-url with trailing slash or path to its origin", () => {
+    const withSlash = createScript({ serverUrl: "https://api.example.com/" });
+    expect(
+      resolveServerUrl({ currentScript: withSlash, fallbackOrigin }),
+    ).toBe("https://api.example.com");
+
+    const withPath = createScript({
+      serverUrl: "https://api.example.com/some/path",
+    });
+    expect(resolveServerUrl({ currentScript: withPath, fallbackOrigin })).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("should fall through to the script src when data-server-url is invalid", () => {
+    const script = createScript({
+      src: "https://my-service.a.run.app/public/widget.js",
+      serverUrl: "not a url",
+    });
+    expect(resolveServerUrl({ currentScript: script, fallbackOrigin })).toBe(
+      "https://my-service.a.run.app",
+    );
+  });
+
+  it("should derive the origin from the current script src", () => {
+    const script = createScript({
+      src: "https://my-service.a.run.app/public/widget.js",
+    });
+    expect(resolveServerUrl({ currentScript: script, fallbackOrigin })).toBe(
+      "https://my-service.a.run.app",
+    );
+  });
+
+  it("should resolve a relative src against the page origin", () => {
+    // demo.html は `/public/widget.js` を相対パスで読み込む。
+    // .src プロパティはブラウザによってページ origin で絶対化される。
+    const script = createScript({ src: "/public/widget.js" });
+    expect(resolveServerUrl({ currentScript: script, fallbackOrigin })).toBe(
+      window.location.origin,
+    );
+  });
+
+  it("should scan for a widget.js script when currentScript is unavailable", () => {
+    const other = createScript({ src: "https://cdn.example/analytics.js" });
+    const widget = createScript({
+      src: "https://backend.example/public/widget.js",
+    });
+    expect(
+      resolveServerUrl({
+        currentScript: null,
+        scripts: [other, widget],
+        fallbackOrigin,
+      }),
+    ).toBe("https://backend.example");
+  });
+
+  it("should pick the last matching script when multiple widget.js tags exist", () => {
+    const first = createScript({ src: "https://old.example/widget.js" });
+    const second = createScript({ src: "https://new.example/widget.js" });
+    expect(
+      resolveServerUrl({
+        currentScript: null,
+        scripts: [first, second],
+        fallbackOrigin,
+      }),
+    ).toBe("https://new.example");
+  });
+
+  it("should return the fallback origin when nothing matches", () => {
+    const other = createScript({ src: "https://cdn.example/analytics.js" });
+    expect(
+      resolveServerUrl({
+        currentScript: null,
+        scripts: [other],
+        fallbackOrigin,
+      }),
+    ).toBe(fallbackOrigin);
+    expect(
+      resolveServerUrl({ currentScript: null, scripts: [], fallbackOrigin }),
+    ).toBe(fallbackOrigin);
+  });
+
+  it("should default to window.location.origin as the last resort", () => {
+    expect(resolveServerUrl({ currentScript: null, scripts: [] })).toBe(
+      window.location.origin,
+    );
+  });
+
+  it("should fall back when the current script is inline (no src, no attribute)", () => {
+    const inline = document.createElement("script");
+    expect(
+      resolveServerUrl({ currentScript: inline, scripts: [], fallbackOrigin }),
+    ).toBe(fallbackOrigin);
+  });
+
+  it("should honor data-server-url on an inline current script", () => {
+    const inline = createScript({ serverUrl: "https://api.example.com" });
+    expect(resolveServerUrl({ currentScript: inline, fallbackOrigin })).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("should ignore a non-script element passed as currentScript", () => {
+    const div = document.createElement("div");
+    const widget = createScript({
+      src: "https://backend.example/public/widget.js",
+    });
+    expect(
+      resolveServerUrl({
+        currentScript: div,
+        scripts: [widget],
+        fallbackOrigin,
+      }),
+    ).toBe("https://backend.example");
+  });
+});

--- a/widget/utils/serverUrl.ts
+++ b/widget/utils/serverUrl.ts
@@ -1,0 +1,82 @@
+export interface ResolveServerUrlOptions {
+  /** 評価中の script 要素（省略時は document.currentScript） */
+  currentScript?: Element | null;
+  /** currentScript が使えない場合に走査する script 要素群（省略時は document 内の script[src]） */
+  scripts?: ArrayLike<HTMLScriptElement>;
+  /** 最終フォールバックの origin（省略時は window.location.origin） */
+  fallbackOrigin?: string;
+}
+
+/**
+ * widget.js を読み込んだ <script> タグから Socket.io サーバーの origin を導出する。
+ *
+ * 埋め込み先サイトの origin にはバックエンドが存在しないため、
+ * `window.location.origin` ではなくスクリプトの配信元（= バックエンドの
+ * Cloud Run URL）へ接続する必要がある。
+ *
+ * 解決順序:
+ * 1. script タグの `data-server-url` 属性（明示指定）
+ * 2. script タグ自身の src の origin
+ * 3. ページの origin（/demo や直接 initChatWidget() 呼び出しの互換維持）
+ */
+export function resolveServerUrl(
+  options: ResolveServerUrlOptions = {},
+): string {
+  const script = findWidgetScript(options);
+
+  if (script) {
+    // パス付きの URL を io() に渡すと Socket.io の namespace として解釈され、
+    // `${serverUrl}/health` 等の fetch も壊れるため、origin のみに正規化する。
+    const explicit = parseOrigin(script.getAttribute("data-server-url"));
+    if (explicit) {
+      return explicit;
+    }
+
+    // .src プロパティはブラウザが絶対 URL に解決済みのため、相対パス読み込み
+    // （/demo など）でもページ origin が得られる。
+    const fromSrc = parseOrigin(script.src);
+    if (fromSrc) {
+      return fromSrc;
+    }
+  }
+
+  return options.fallbackOrigin ?? window.location.origin;
+}
+
+function findWidgetScript(
+  options: ResolveServerUrlOptions,
+): HTMLScriptElement | null {
+  const current = options.currentScript ?? document.currentScript;
+  if (current instanceof HTMLScriptElement) {
+    return current;
+  }
+
+  // async 属性付きの動的挿入やコールバック内実行では currentScript が null に
+  // なるため、widget.js を指す script タグを走査する。重複埋め込み時は
+  // 最後に追加されたタグ（後勝ち）を採用する。
+  const scripts =
+    options.scripts ??
+    document.querySelectorAll<HTMLScriptElement>("script[src]");
+  for (let i = scripts.length - 1; i >= 0; i--) {
+    const candidate = scripts[i];
+    try {
+      if (new URL(candidate.src).pathname.endsWith("/widget.js")) {
+        return candidate;
+      }
+    } catch {
+      // 不正な src は無視して次の候補へ
+    }
+  }
+  return null;
+}
+
+function parseOrigin(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}

--- a/widget/utils/socketHandler.test.ts
+++ b/widget/utils/socketHandler.test.ts
@@ -2,13 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { ioMock, fakeSocket } = vi.hoisted(() => {
     const handlers: Record<string, (...args: unknown[]) => void> = {};
+    const managerHandlers: Record<string, (...args: unknown[]) => void> = {};
     const fakeSocket = {
         handlers,
+        managerHandlers,
         connected: false,
         on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
             handlers[event] = cb;
         }),
+        io: {
+            on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+                managerHandlers[event] = cb;
+            }),
+        },
         emit: vi.fn(),
+        connect: vi.fn(),
         disconnect: vi.fn(),
     };
     return { ioMock: vi.fn(() => fakeSocket), fakeSocket };
@@ -22,6 +30,7 @@ describe('initSocketHandler', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         for (const key of Object.keys(fakeSocket.handlers)) delete fakeSocket.handlers[key];
+        for (const key of Object.keys(fakeSocket.managerHandlers)) delete fakeSocket.managerHandlers[key];
         fakeSocket.connected = false;
     });
 
@@ -41,9 +50,25 @@ describe('initSocketHandler', () => {
         setup();
         // addTrailingSlash: false を明示し、末尾スラッシュを除去するプロキシ
         // (Firebase App Hosting 等) の背後でも 404 にならないようにする。
+        // 再接続は上限付きバックオフとし、404 への無限リトライを防ぐ。
         expect(ioMock).toHaveBeenCalledWith('http://localhost', {
             addTrailingSlash: false,
+            reconnectionAttempts: 10,
+            reconnectionDelay: 1000,
+            reconnectionDelayMax: 30000,
         });
+    });
+
+    it('should warn (not spam the chat) when reconnection gives up', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { cbs } = setup();
+
+        expect(fakeSocket.managerHandlers['reconnect_failed']).toBeDefined();
+        fakeSocket.managerHandlers['reconnect_failed']();
+
+        expect(warnSpy).toHaveBeenCalled();
+        expect(cbs.onError).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
     });
 
     it('should route socket events to the corresponding callbacks', () => {
@@ -76,6 +101,18 @@ describe('initSocketHandler', () => {
         expect(() => fakeSocket.handlers['connect']()).not.toThrow();
         expect(() => fakeSocket.handlers['response-complete']()).not.toThrow();
         expect(handler).toBeTruthy();
+    });
+
+    it('should reconnect on user input after retries were exhausted', () => {
+        const { handler } = setup();
+
+        fakeSocket.connected = false;
+        handler.sendUserInput('hello', false);
+        expect(fakeSocket.connect).toHaveBeenCalledTimes(1);
+
+        fakeSocket.connected = true;
+        handler.sendUserInput('hello again', false);
+        expect(fakeSocket.connect).toHaveBeenCalledTimes(1);
     });
 
     it('should emit user-input with default language ja', () => {

--- a/widget/utils/socketHandler.ts
+++ b/widget/utils/socketHandler.ts
@@ -33,7 +33,24 @@ export function initSocketHandler(
   // Firebase App Hosting などのプロキシは既定の `/socket.io/` から末尾スラッシュを
   // 除去して転送し、サーバ側でパスが一致せず 404 になることがある。クライアント側でも
   // 末尾スラッシュを付けずに接続し、サーバの設定と揃える。
-  const socket: Socket = io(serverUrl, { addTrailingSlash: false });
+  const socket: Socket = io(serverUrl, {
+    addTrailingSlash: false,
+    // 接続先が恒久的に 404 を返す場合（誤設定など）に無限リトライで
+    // リクエストを流し続けないよう、試行回数に上限を設ける。
+    // 初回リトライは 1 秒で一時切断からの低遅延復帰を維持しつつ、
+    // 指数バックオフで最大 30 秒まで間隔を広げる（計 ~10 回 / ~3 分）。
+    reconnectionAttempts: 10,
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 30000,
+  });
+
+  socket.io.on("reconnect_failed", () => {
+    // ウィジェットを開いていないページでも動作するため、チャット欄への
+    // エラー表示はせず console 警告に留める。
+    console.warn(
+      "[MakaseteAI] サーバーに接続できないため自動再接続を停止しました",
+    );
+  });
 
   socket.on("connect", () => {
     onConnect?.();
@@ -63,6 +80,10 @@ export function initSocketHandler(
   });
 
   function sendUserInput(text: string, isVoiceInput: boolean, language = "ja"): void {
+    // リトライ上限到達後もユーザー操作を契機に接続を復帰できるようにする
+    if (!socket.connected) {
+      socket.connect();
+    }
     socket.emit("user-input", { text, isVoiceInput, language });
   }
 

--- a/widget/widget.ts
+++ b/widget/widget.ts
@@ -13,6 +13,7 @@ import {
   MessageState,
 } from "./utils/uiRenderer";
 import { parseSettings } from "./utils/settings";
+import { resolveServerUrl } from "./utils/serverUrl";
 
 interface WidgetConfig {
   serverUrl?: string;
@@ -78,7 +79,7 @@ function buildWidgetMarkup(placeholder: string, helperText: string): string {
 
 export function initChatWidget(config: WidgetConfig = {}): void {
   const {
-    serverUrl = window.location.origin,
+    serverUrl = resolveServerUrl(),
     title = "AIアシスタント",
     placeholder = "質問を入力...",
     language = "ja",


### PR DESCRIPTION
## 背景

埋め込みサイト `makasete-ai.nisyuu.com/nisyuu-store` で `/socket.io` への GET が 404 を返し続け、Cloud Run(asia-southeast1・Firebase App Hosting 管理)にリクエストが大量に流れていた。`/demo` は正常。

※ 対応する Issue はなし(Cloud Run ログからの報告に基づく修正)。

## 原因

1. **接続先の誤り**: ウィジェットは接続先を常に `window.location.origin` にしていた(`widget/main.ts`)。埋め込み先ページの origin にはこのバックエンドが存在しないため 404 になる。`/demo` はバックエンド自身から配信されるため origin が一致し正常だった。
2. **無限リトライ**: `io()` に再接続オプションが未指定で、socket.io-client v4 のデフォルト(無限再接続・1〜5秒間隔)により 404 に対してリクエストが延々と送られ続けていた。

## 変更内容

- **`widget/utils/serverUrl.ts`(新規)**: widget.js を読み込んだ `<script>` タグから接続先 origin を導出する `resolveServerUrl()` を追加。優先順位は ① `data-server-url` 属性(origin に正規化)→ ② スクリプト自身の src の origin → ③ `window.location.origin`。既存の埋め込みスニペットは変更不要で、新しい widget.js の再取得時点で解消する。
- **`widget/utils/socketHandler.ts`**: 再接続を上限付き指数バックオフに変更(`reconnectionAttempts: 10`、1s→最大30s、計~3分で停止)。上限到達後もユーザーのメッセージ送信を契機に `socket.connect()` で復帰可能。
- **`widget/widget.ts` / `widget/main.ts`**: `serverUrl` のデフォルトを `resolveServerUrl()` に変更(`/health`・`/api/settings` の fetch も同じ URL を使うため併せて解消)。
- **テスト**: `serverUrl.test.ts`(新規・12ケース)、`socketHandler.test.ts` 更新。213 テストすべて成功、カバレッジ閾値(80%)維持。
- **README**: 自動接続の仕様と `data-server-url` 属性、`ALLOWED_ORIGINS` の注意を追記。

## 検証

- `pnpm typecheck` / `pnpm lint` / `pnpm test`(213 passed)/ `pnpm build:widget` すべて成功
- Chromium 実機検証: 別 origin のページに widget.js を埋め込み、socket.io ポーリングがページ origin ではなくスクリプト配信元に向かうこと、`data-server-url`(パス・末尾スラッシュ付き)が origin に正規化されて接続されることを確認

## 運用側の対応(コード外)

- 本番の `ALLOWED_ORIGINS`(`terraform/main.tf`)に `https://makasete-ai.nisyuu.com` が含まれていることを確認してください(クロスオリジン接続になるため)。
- asia-southeast1 側の Cloud Run(Firebase App Hosting 管理)は本リポジトリ外のデプロイであり、404 フラッドは埋め込みサイトが新しい widget.js を取得した時点で解消します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw4Rn6EkibXi3xmmL5o5n6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw4Rn6EkibXi3xmmL5o5n6)_