### PR TITLE
fix(widget): 日本語音声入力で認識結果に混入するスペースを除去して文章を繋げる

### DIFF
--- a/widget/utils/audioHandler.test.ts
+++ b/widget/utils/audioHandler.test.ts
@@ -314,6 +314,51 @@ describe('initAudioHandler', () => {
             expect(opts.onRecordingEnd).toHaveBeenCalledWith('こんにちはまた明日');
         });
 
+        it('should join Japanese transcripts by stripping recognizer-inserted spaces', () => {
+            const { opts } = setup({ language: 'ja' });
+            const rec = createdRecognitions[0];
+
+            // 認識エンジンはフレーズ間にスペース（半角・全角）を挿入することがある。
+            // 日本語はスペースで区切らないため、プレビュー段階から除去して繋げる。
+            rec.onresult!(
+                makeResultEvent(0, [{ transcript: 'こんにちは 今日は　いい天気', isFinal: false }]),
+            );
+            expect(opts.onTranscript).toHaveBeenLastCalledWith('こんにちは今日はいい天気');
+
+            rec.onresult!(
+                makeResultEvent(0, [{ transcript: 'こんにちは 今日は いい天気 ですね', isFinal: true }]),
+            );
+            rec.onend!();
+            expect(opts.onRecordingEnd).toHaveBeenCalledWith('こんにちは今日はいい天気ですね');
+        });
+
+        it('should join Japanese final segments without spaces between them', () => {
+            const { opts } = setup({ language: 'ja' });
+            const rec = createdRecognitions[0];
+
+            // 複数の確定セグメントが先頭スペース付きで届いても繋がった文章になる
+            // （event.results は累積なので 2 回目は resultIndex=1 で新規分のみ加算される）
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'おはよう', isFinal: true }]));
+            rec.onresult!(
+                makeResultEvent(1, [
+                    { transcript: 'おはよう', isFinal: true },
+                    { transcript: ' ございます', isFinal: true },
+                ]),
+            );
+
+            rec.onend!();
+            expect(opts.onRecordingEnd).toHaveBeenCalledWith('おはようございます');
+        });
+
+        it('should preserve spaces for English transcripts', () => {
+            const { opts } = setup({ language: 'en' });
+            const rec = createdRecognitions[0];
+
+            rec.onresult!(makeResultEvent(0, [{ transcript: 'good morning everyone', isFinal: true }]));
+            rec.onend!();
+            expect(opts.onRecordingEnd).toHaveBeenCalledWith('good morning everyone');
+        });
+
         it('should reset accumulated text between recordings', () => {
             const { handler, opts } = setup();
             const rec = createdRecognitions[0];

--- a/widget/utils/audioHandler.ts
+++ b/widget/utils/audioHandler.ts
@@ -174,7 +174,14 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
 
     const rec = new SpeechRecognitionAPI();
     recognition = rec;
-    rec.lang = language === "en" ? "en-US" : "ja-JP";
+    const recognitionLang = language === "en" ? "en-US" : "ja-JP";
+    // 日本語は単語をスペースで区切らないため、認識エンジンがフレーズ間に
+    // 挿入するスペースを除去して文章を繋げる。英語はスペースが語の区切り
+    // として必要なのでそのまま残す。
+    const stripSpaces = recognitionLang === "ja-JP";
+    const normalizeTranscript = (text: string): string =>
+      stripSpaces ? text.replace(/\s+/g, "") : text;
+    rec.lang = recognitionLang;
     rec.continuous = false;
     // 認識途中の結果も受け取り、入力欄にプレビュー表示する。
     // ただし送信は発話が確定して録音が終了する onend のタイミングで一度だけ行う。
@@ -186,7 +193,7 @@ export function initAudioHandler(options: AudioHandlerOptions): AudioHandler {
       let interim = "";
       for (let i = event.resultIndex; i < event.results.length; i++) {
         const result = event.results[i];
-        const transcript = result[0].transcript;
+        const transcript = normalizeTranscript(result[0].transcript);
         if (result.isFinal) {
           finalTranscript += transcript;
         } else {


### PR DESCRIPTION
## 概要

音声入力した文章の所々にスペースが混入する問題を修正し、日本語の発話が繋がった文章として入力されるようにします。

※ 対応する Issue は存在しないため `closes` の記載はありません（直接依頼による修正）。

## 原因

Web Speech API（Google の認識エンジン）は、日本語でも認識フレーズの区切りに半角・全角スペースを挿入して transcript を返すことがあります。`widget/utils/audioHandler.ts` の `onresult` では transcript をそのまま連結していたため、このスペースがプレビュー表示・送信テキストの両方に残っていました。

## 変更内容

- `widget/utils/audioHandler.ts`: 認識言語が `ja-JP` の場合、認識結果（確定・未確定とも）から空白（半角・全角）を除去してから連結する `normalizeTranscript` を追加。プレビュー段階から繋がった文章で表示されます。
- 英語（`en-US`）はスペースが語の区切りとして必要なため、従来どおり保持します。
- `widget/utils/audioHandler.test.ts`: 以下のテストを追加
  - 日本語 transcript 内のスペース（半角・全角）が除去されて繋がること
  - 複数の確定セグメントが先頭スペース付きで届いても繋がること
  - 英語ではスペースが保持されること

## 動作確認

- `pnpm test` : 216 件すべてパス
- `pnpm typecheck` : パス
- `pnpm lint` : パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS55VszEBGagfpHpTFJrq4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TS55VszEBGagfpHpTFJrq4)_