### PR TITLE
ci: TypeScript を v6 に固定して lint 失敗を解消（typescript-eslint が v7 未対応のため）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,15 @@ updates:
       interval: "weekly"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    ignore:
+      # typescript-eslint (v8) が TypeScript 7 に未対応のため、
+      # typescript のメジャーアップデート (7.x 以降) を保留する。
+      # TypeScript 7 は tsc がネイティブ移植された版で `ts.Extension` 等の
+      # 内部 API が変わり、@typescript-eslint/typescript-estree が読み込み時に
+      # クラッシュして lint が失敗する (peer: typescript ">=4.8.4 <6.1.0")。
+      # typescript-eslint が TypeScript 7 に対応したら、この ignore を解除すること。
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       patch-updates:
         patterns:


### PR DESCRIPTION
## 概要

Dependabot の major-updates PR（#268: `typescript` 6.0.3 → 7.0.2）で CI が落ちている問題を解消します。TypeScript 7 は現時点で lint ツールチェーンが未対応のため、`typescript` のメジャーアップデートを Dependabot の `ignore` に追加し、6.x に固定します。

## 原因

CI の **lint** ステップが以下で失敗していました。

```
ESLint: 10.7.0
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at .../@typescript-eslint/typescript-estree@8.63.0_typescript@7.0.2/dist/create-program/shared.js:59
```

- `typescript-eslint@8.63.0`（および `@typescript-eslint/typescript-estree`）の peer は `typescript ">=4.8.4 <6.1.0"` で、**TypeScript 7 に未対応**です。
- 現時点で TypeScript 7 に対応した `typescript-eslint` の安定版リリースは存在しません（`latest` = 8.63.0 = 落ちている当該バージョン）。
- TypeScript 7 は `tsc` がネイティブ移植された版で `ts.Extension` 等の内部 API が変わったため、`typescript-estree` が読み込み時にクラッシュし、TS ファイルの lint が全て失敗します。
- `pnpm add -D typescript@7.0.2` → `pnpm lint` でローカル再現も確認済み（peer 警告 `unmet peer typescript@">=4.8.4 <6.1.0": found 7.0.2` の後、上記クラッシュ）。

`package.json` の `^6.0.3` は範囲上 7.x を許可しませんが、Dependabot はマニフェスト自体を書き換えて major を上げてくるため、range 指定だけでは抑止できません。Dependabot の `ignore` が正しい抑止手段です。

## 変更内容

- `.github/dependabot.yml` の npm ecosystem に `ignore` を追加し、`typescript` の `version-update:semver-major` を保留。
- 経緯と、`typescript-eslint` が TS7 に対応したら解除する旨をコメントで明記。

```yaml
    ignore:
      - dependency-name: "typescript"
        update-types: ["version-update:semver-major"]
```

`.github/workflows/` は変更していません（リポジトリ規約により変更禁止のため）。

## 確認

- `pnpm lint` / `pnpm typecheck` / `pnpm test`（216 件）すべてパス（本 PR は依存を変更せず、`typescript` は 6.0.3 のまま）。
- `.github/dependabot.yml` の YAML パース・`ignore` 反映を確認済み。

## 補足

本 PR がマージされると、次回の Dependabot 実行で当該メジャーアップデート（#268）は無視対象となり自動的にクローズされます。TypeScript 7 への移行は `typescript-eslint` の対応後に、この `ignore` を解除して改めて対応してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsUo9z9jBJcWnqxt5tarsh)_